### PR TITLE
Fix license headers, add license header template

### DIFF
--- a/LICENSE.header
+++ b/LICENSE.header
@@ -1,0 +1,16 @@
+/*
+ * This file is part of mesamatrix.
+ *
+ * mesamatrix is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * mesamatrix is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with mesamatrix. If not, see <http://www.gnu.org/licenses/>.
+ */

--- a/http/css/style.css
+++ b/http/css/style.css
@@ -11,10 +11,10 @@
  * mesamatrix is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with libbench. If not, see <http://www.gnu.org/licenses/>.
+ * along with mesamatrix. If not, see <http://www.gnu.org/licenses/>.
  */
 
 body { font-size: 85%; font-family: sans-serif; }

--- a/http/index.php
+++ b/http/index.php
@@ -12,10 +12,10 @@
  * mesamatrix is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with libbench. If not, see <http://www.gnu.org/licenses/>.
+ * along with mesamatrix. If not, see <http://www.gnu.org/licenses/>.
  */
 
 ///////////////////////////////////////

--- a/http/js/script.js
+++ b/http/js/script.js
@@ -11,10 +11,10 @@
  * mesamatrix is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with libbench. If not, see <http://www.gnu.org/licenses/>.
+ * along with mesamatrix. If not, see <http://www.gnu.org/licenses/>.
  */
 
 function fillZeros(number, size)

--- a/lib/commitsparser.php
+++ b/lib/commitsparser.php
@@ -12,10 +12,10 @@
  * mesamatrix is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with libbench. If not, see <http://www.gnu.org/licenses/>.
+ * along with mesamatrix. If not, see <http://www.gnu.org/licenses/>.
  */
 
 class CommitsParser

--- a/lib/hints.php
+++ b/lib/hints.php
@@ -12,10 +12,10 @@
  * mesamatrix is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with libbench. If not, see <http://www.gnu.org/licenses/>.
+ * along with mesamatrix. If not, see <http://www.gnu.org/licenses/>.
  */
 
 class Hints

--- a/lib/oglparser.php
+++ b/lib/oglparser.php
@@ -12,10 +12,10 @@
  * mesamatrix is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with libbench. If not, see <http://www.gnu.org/licenses/>.
+ * along with mesamatrix. If not, see <http://www.gnu.org/licenses/>.
  */
 
 // List of all the drivers.


### PR DESCRIPTION
Instances of 'libbench' were replaced with 'mesamatrix', and instances of 'GNU Lesser General Public License' were replaced with 'GNU General Public License'

You should always check before copying a license header from other projects :laughing:
