### PR TITLE
Cache URL requests into a file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/private/
 /mesa.git/
 /http/gl3.xml
 /config/config.php

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 /private/
-/mesa.git/
 /http/gl3.xml
 /config/config.php
 *.swp

--- a/config/config.default.php
+++ b/config/config.default.php
@@ -17,11 +17,13 @@ $CONFIG = array(
             "Tobias Droste",
             "Robin McCorkell" => "mailto:rmccorkell@karoshi.org.uk",
         ),
+        "private_dir" => "private",
     ),
 
     "opengl_links" => array(
         "enabled" => TRUE,
         "url" => "https://www.opengl.org/registry/specs/",
+        "cache_file" => "urlcache.json",
     ),
 
     "flattr" => array(

--- a/lib/git/processbuilder.php
+++ b/lib/git/processbuilder.php
@@ -26,7 +26,8 @@ class ProcessBuilder extends \Symfony\Component\Process\ProcessBuilder
     public function __construct(array $arguments = array())
     {
         array_unshift($arguments, 'git');
-        $gitDir = \Mesamatrix::path(\Mesamatrix::$config->getValue("git", "dir"));
+        $gitDir = \Mesamatrix::path(\Mesamatrix::$config->getValue("info", "private_dir"))."/";
+        $gitDir .= \Mesamatrix::$config->getValue("git", "dir");
         foreach ($arguments as &$arg) {
             $arg = str_replace('@gitDir@', $gitDir, $arg);
         }

--- a/lib/parser/urlcache.php
+++ b/lib/parser/urlcache.php
@@ -1,0 +1,114 @@
+<?php
+/*
+ * Copyright (C) 2014 Romain "Creak" Failliot.
+ *
+ * This file is part of mesamatrix.
+ *
+ * mesamatrix is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * mesamatrix is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with mesamatrix. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace Mesamatrix\Parser;
+
+class UrlCache
+{
+    const EXPIRATIONDELAY = 90 * 24 * 60 * 60;  // 90 days.
+
+    /**
+     * Default constructor.
+     */
+    public function __construct() {
+        $this->instanceTime = time();
+        $this->cachedUrls = array();
+    }
+
+    /**
+     * Load the URL cache file.
+     *
+     * This file is encoded in JSON.
+     */
+    public function load() {
+        $privateDir = \Mesamatrix::$config->getValue("info", "private_dir", "private");
+        $filepath = $privateDir.'/'.\Mesamatrix::$config->getValue("opengl_links", "cache_file", "urlcache.json");
+        if (file_exists($filepath) !== FALSE) {
+            $urlCacheContents = file_get_contents($filepath);
+            if ($urlCacheContents !== FALSE) {
+                $this->cachedUrls = json_decode($urlCacheContents, true);
+                \Mesamatrix::debug_print("URL cache file loaded.");
+            }
+        }
+    }
+
+    /**
+     * Save the URL cache file.
+     *
+     * This file is encoded in JSON.
+     */
+    public function save() {
+        $privateDir = \Mesamatrix::$config->getValue("info", "private_dir", "private");
+        if (file_exists($privateDir) === FALSE)
+            mkdir($privateDir, 0777, true);
+        $filepath = $privateDir.'/'.\Mesamatrix::$config->getValue("opengl_links", "cache_file", "urlcache.json");
+        $res = file_put_contents($filepath, json_encode($this->cachedUrls));
+        if ($res !== FALSE)
+            \Mesamatrix::debug_print("URL cache file saved: ".$filepath.".");
+        else
+            \Mesamatrix::debug_print("Can't save URL cache file in \"".$filepath."\".");
+    }
+
+    /**
+     * Return if the URL is valid or not.
+     *
+     * Also update the URL in the database if needed.
+     *
+     * @param string $url URL to test.
+     */
+    public function isValid($url) {
+        if ($this->needCheck($url))
+            $this->updateUrl($url);
+        return $this->cachedUrls[$url]['is_valid'];
+    }
+
+    /**
+     * Get if an url need to be checked or not.
+     *
+     * @param string $url URL to test.
+     * @return boolean Whether or not the given URL need to be checked again.
+     */
+    private function needCheck($url) {
+        $urlKnown = array_key_exists($url, $this->cachedUrls);
+        return !$urlKnown || $this->cachedUrls[$url]['expiration_date'] < $this->instanceTime;
+    }
+
+    /**
+     * Update the URL in the database.
+     *
+     * @param string $url URL to update.
+     */
+    private function updateUrl($url) {
+        $urlHeader = get_headers($url);
+        $isValid = FALSE;
+        if ($urlHeader !== FALSE) {
+            \Mesamatrix::debug_print("Try URL \"".$url."\". Result: \"".$urlHeader[0]."\".");
+            $isValid = $urlHeader[0] === "HTTP/1.1 200 OK";
+        }
+
+        // Register URL's validity.
+        $this->cachedUrls[$url] = array(
+            'expiration_date' => $this->instanceTime + self::EXPIRATIONDELAY,
+            'is_valid' => $isValid);
+    }
+
+    private $instanceTime;
+    private $cachedUrls;
+}


### PR DESCRIPTION
0005c73:
* In order to prevent HTTP requests for each OpenGL URLs, each time Mesamatrix is updating (i.e. fetch and parse) itself, store the results of these requests into a file (private/urlcache.json) and keep them for 90 days until testing them again (each request has its own expiration date).
* In order to prevent having generated files everywhere, I created a "private" directory (that is configurable). The "urlcache.json" file name is also configurable. But the expiration delay is not.

94a8e52:
* And since there is a dedicated directory for the internal stuff used by Mesamatrix, I moved mesa.git into it too.