### PR TITLE
Introduce Monolog support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,10 @@
     "require": {
         "symfony/console": "^2.6",
         "symfony/process": "^2.6",
-        "psr/log": "1.0.0"
+        "psr/log": "1.0.0",
+        "monolog/monolog": "~1.12",
+        "symfony/monolog-bridge": "~2.6",
+        "symfony/event-dispatcher": "~2.6"
     },
 
     "autoload": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,80 @@
         "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "7e113ead56fbe1bcad12a855d24c5e80",
+    "hash": "3977f759805266854dcac48fb3c600c7",
     "packages": [
+        {
+            "name": "monolog/monolog",
+            "version": "1.12.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Seldaek/monolog.git",
+                "reference": "1fbe8c2641f2b163addf49cc5e18f144bec6b19f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Seldaek/monolog/zipball/1fbe8c2641f2b163addf49cc5e18f144bec6b19f",
+                "reference": "1fbe8c2641f2b163addf49cc5e18f144bec6b19f",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0",
+                "psr/log": "~1.0"
+            },
+            "provide": {
+                "psr/log-implementation": "1.0.0"
+            },
+            "require-dev": {
+                "aws/aws-sdk-php": "~2.4, >2.4.8",
+                "doctrine/couchdb": "~1.0@dev",
+                "graylog2/gelf-php": "~1.0",
+                "phpunit/phpunit": "~4.0",
+                "raven/raven": "~0.5",
+                "ruflin/elastica": "0.90.*",
+                "videlalvaro/php-amqplib": "~2.4"
+            },
+            "suggest": {
+                "aws/aws-sdk-php": "Allow sending log messages to AWS services like DynamoDB",
+                "doctrine/couchdb": "Allow sending log messages to a CouchDB server",
+                "ext-amqp": "Allow sending log messages to an AMQP server (1.0+ required)",
+                "ext-mongo": "Allow sending log messages to a MongoDB server",
+                "graylog2/gelf-php": "Allow sending log messages to a GrayLog2 server",
+                "raven/raven": "Allow sending log messages to a Sentry server",
+                "rollbar/rollbar": "Allow sending log messages to Rollbar",
+                "ruflin/elastica": "Allow sending log messages to an Elastic Search server",
+                "videlalvaro/php-amqplib": "Allow sending log messages to an AMQP server using php-amqplib"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.12.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Monolog\\": "src/Monolog"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be",
+                    "homepage": "http://seld.be"
+                }
+            ],
+            "description": "Sends your logs to files, sockets, inboxes, databases and various web services",
+            "homepage": "http://github.com/Seldaek/monolog",
+            "keywords": [
+                "log",
+                "logging",
+                "psr-3"
+            ],
+            "time": "2014-12-29 21:29:35"
+        },
         {
             "name": "psr/log",
             "version": "1.0.0",
@@ -100,6 +172,122 @@
             "description": "Symfony Console Component",
             "homepage": "http://symfony.com",
             "time": "2015-01-25 04:39:26"
+        },
+        {
+            "name": "symfony/event-dispatcher",
+            "version": "v2.6.4",
+            "target-dir": "Symfony/Component/EventDispatcher",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/EventDispatcher.git",
+                "reference": "f75989f3ab2743a82fe0b03ded2598a2b1546813"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/EventDispatcher/zipball/f75989f3ab2743a82fe0b03ded2598a2b1546813",
+                "reference": "f75989f3ab2743a82fe0b03ded2598a2b1546813",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "require-dev": {
+                "psr/log": "~1.0",
+                "symfony/config": "~2.0,>=2.0.5",
+                "symfony/dependency-injection": "~2.6",
+                "symfony/expression-language": "~2.6",
+                "symfony/stopwatch": "~2.3"
+            },
+            "suggest": {
+                "symfony/dependency-injection": "",
+                "symfony/http-kernel": ""
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.6-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Symfony\\Component\\EventDispatcher\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Symfony Community",
+                    "homepage": "http://symfony.com/contributors"
+                },
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                }
+            ],
+            "description": "Symfony EventDispatcher Component",
+            "homepage": "http://symfony.com",
+            "time": "2015-02-01 16:10:57"
+        },
+        {
+            "name": "symfony/monolog-bridge",
+            "version": "v2.6.4",
+            "target-dir": "Symfony/Bridge/Monolog",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/MonologBridge.git",
+                "reference": "83a451b5a2e16a14ffd07a42746c4b9db1a48c1d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/MonologBridge/zipball/83a451b5a2e16a14ffd07a42746c4b9db1a48c1d",
+                "reference": "83a451b5a2e16a14ffd07a42746c4b9db1a48c1d",
+                "shasum": ""
+            },
+            "require": {
+                "monolog/monolog": "~1.11",
+                "php": ">=5.3.3"
+            },
+            "require-dev": {
+                "symfony/console": "~2.4",
+                "symfony/event-dispatcher": "~2.2",
+                "symfony/http-kernel": "~2.4"
+            },
+            "suggest": {
+                "symfony/console": "For the possibility to show log messages in console commands depending on verbosity settings. You need version ~2.3 of the console for it.",
+                "symfony/event-dispatcher": "Needed when using log messages in console commands",
+                "symfony/http-kernel": "For using the debugging handlers together with the response life cycle of the HTTP kernel."
+            },
+            "type": "symfony-bridge",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.6-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Symfony\\Bridge\\Monolog\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Symfony Community",
+                    "homepage": "http://symfony.com/contributors"
+                },
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                }
+            ],
+            "description": "Symfony Monolog Bridge",
+            "homepage": "http://symfony.com",
+            "time": "2015-01-03 08:01:59"
         },
         {
             "name": "symfony/process",

--- a/config/config.default.php
+++ b/config/config.default.php
@@ -3,9 +3,21 @@
 // Default configuration for MesaMatrix
 // Copy to config/config.php for use
 
+use \Monolog\Logger as Log;
+/* available log levels:
+ * Log::EMERGENCY
+ * Log::ALERT
+ * Log::CRITICAL
+ * Log::ERROR
+ * Log::WARNING (default)
+ * Log::NOTICE
+ * Log::INFO
+ * Log::DEBUG
+ */
+
 $CONFIG = array(
     "info" => array(
-        "debug" => FALSE,
+        "log_level" => Log::WARNING,
         "version" => "1.0",
         "title" => "The OpenGL vs Mesa matrix",
         "description" => "Show Mesa progress for the OpenGL implementation into an easy to read HTML page.",

--- a/http/index.php
+++ b/http/index.php
@@ -28,7 +28,8 @@ $gl3Path = Mesamatrix::path(Mesamatrix::$config->getValue("info", "xml_file"));
 // Read "xml_file".
 $xml = simplexml_load_file($gl3Path);
 if (!$xml) {
-    exit("Can't read '".$gl3Path."'");
+    \Mesamatrix::$logger->critical("Can't read ".$gl3Path);
+    exit();
 }
 
 // Set all the versions in an array so that it can be sorted out.

--- a/lib/CommitsParser.php
+++ b/lib/CommitsParser.php
@@ -69,6 +69,7 @@ class CommitsParser
                     $line = fgets($handle);
                 }
 
+                \Mesamatrix::$logger->debug('Added commit '.$hash);
                 $commits[] = array(
                     "hash" => $hash,
                     "timestamp" => $timestamp,

--- a/lib/Config.php
+++ b/lib/Config.php
@@ -22,7 +22,6 @@ namespace Mesamatrix;
 
 class Config
 {
-    protected $debugMode;
     protected $cache = array();
 
     public function __construct($configDir) {
@@ -35,25 +34,6 @@ class Config
             foreach ($extraConfigs as $config) {
                 $this->readData($config);
             }
-        }
-
-        $this->debug($this->getValue('info', 'debug', false));
-    }
-
-    public function debug($set = null) {
-        if (is_null($set)) {
-            return $this->debugMode;
-        }
-        elseif ($set) {
-            ini_set('display_errors', 1);
-            ini_set('error_reporting', E_ALL);
-            $this->debugMode = true;
-        }
-        else
-        {
-            ini_set('display_errors', 0);
-            ini_set('error_reporting', E_ALL & ~E_NOTICE & ~E_STRICT & ~E_DEPRECATED);
-            $this->debugMode = false;
         }
     }
 
@@ -68,6 +48,7 @@ class Config
 
     public function readData($configFile) {
         if (file_exists($configFile)) {
+            \Mesamatrix::$logger->info('Loading configuration file '.$configFile);
             @include $configFile;
             if (isset($CONFIG) && is_array($CONFIG)) {
                 foreach ($CONFIG as $section => $sectionConfig) {

--- a/lib/Console/Application.php
+++ b/lib/Console/Application.php
@@ -34,6 +34,10 @@ class Application extends \Symfony\Component\Console\Application
     {
         // Set default output verbosity
         $output->setVerbosity(OutputInterface::VERBOSITY_VERY_VERBOSE);
+        \Mesamatrix::$logger = new \Monolog\Logger('cli-logger');
+        \Mesamatrix::$logger->pushHandler(
+            new \Symfony\Bridge\Monolog\Handler\ConsoleHandler($output)
+        );
         return parent::configureIO($input, $output);
     }
 

--- a/lib/Console/Command/Setup.php
+++ b/lib/Console/Command/Setup.php
@@ -36,7 +36,7 @@ class Setup extends \Symfony\Component\Console\Command\Command
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $git = new \Mesamatrix\Git\ProcessBuilder(array(
-          'clone', '--bare', '--depth', \Mesamatrix::$config->getValue('git', 'depth'),
+          'clone', '--bare', '--depth', \Mesamatrix::$config->getValue('git', 'depth', 6000),
           \Mesamatrix::$config->getValue('git', 'url'), '@gitDir@'
         ));
         $this->getHelper('process')->mustRun($output, $git->getProcess());

--- a/lib/Git/ProcessBuilder.php
+++ b/lib/Git/ProcessBuilder.php
@@ -27,7 +27,7 @@ class ProcessBuilder extends \Symfony\Component\Process\ProcessBuilder
     {
         array_unshift($arguments, 'git');
         $gitDir = \Mesamatrix::path(\Mesamatrix::$config->getValue("info", "private_dir"))."/";
-        $gitDir .= \Mesamatrix::$config->getValue("git", "dir");
+        $gitDir .= \Mesamatrix::$config->getValue("git", "dir", "mesa.git");
         foreach ($arguments as &$arg) {
             $arg = str_replace('@gitDir@', $gitDir, $arg);
         }

--- a/lib/Parser/UrlCache.php
+++ b/lib/Parser/UrlCache.php
@@ -38,13 +38,13 @@ class UrlCache
      * This file is encoded in JSON.
      */
     public function load() {
-        $privateDir = \Mesamatrix::$config->getValue("info", "private_dir", "private");
+        $privateDir = \Mesamatrix::$config->getValue("info", "private_dir");
         $filepath = $privateDir.'/'.\Mesamatrix::$config->getValue("opengl_links", "cache_file", "urlcache.json");
         if (file_exists($filepath) !== FALSE) {
             $urlCacheContents = file_get_contents($filepath);
             if ($urlCacheContents !== FALSE) {
                 $this->cachedUrls = json_decode($urlCacheContents, true);
-                \Mesamatrix::debug_print("URL cache file loaded.");
+                \Mesamatrix::$logger->notice("URL cache file loaded.");
             }
         }
     }
@@ -61,9 +61,9 @@ class UrlCache
         $filepath = $privateDir.'/'.\Mesamatrix::$config->getValue("opengl_links", "cache_file", "urlcache.json");
         $res = file_put_contents($filepath, json_encode($this->cachedUrls));
         if ($res !== FALSE)
-            \Mesamatrix::debug_print("URL cache file saved: ".$filepath.".");
+            \Mesamatrix::$logger->notice("URL cache file saved: ".$filepath.".");
         else
-            \Mesamatrix::debug_print("Can't save URL cache file in \"".$filepath."\".");
+            \Mesamatrix::$logger->error("Can't save URL cache file in \"".$filepath."\".");
     }
 
     /**
@@ -99,7 +99,7 @@ class UrlCache
         $urlHeader = get_headers($url);
         $isValid = FALSE;
         if ($urlHeader !== FALSE) {
-            \Mesamatrix::debug_print("Try URL \"".$url."\". Result: \"".$urlHeader[0]."\".");
+            \Mesamatrix::$logger->info("Try URL \"".$url."\". Result: \"".$urlHeader[0]."\".");
             $isValid = $urlHeader[0] === "HTTP/1.1 200 OK";
         }
 

--- a/lib/base.php
+++ b/lib/base.php
@@ -18,29 +18,50 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+use Monolog\Logger;
+use Monolog\ErrorHandler;
+use Monolog\Handler\ErrorLogHandler;
+use Monolog\Handler\StreamHandler;
+
 class Mesamatrix
 {
     public static $serverRoot; // Path to root of installation
     public static $configDir; // Path to configuration directory
     public static $config; // Config object
     public static $autoloader; // Autoloader
+    public static $logger; // Logger
 
     public static function init() {
+        date_default_timezone_set('UTC');
+
         $dir = str_replace("\\", '/', __DIR__);
         self::$serverRoot = implode('/', array_slice(explode('/', $dir), 0, -1));
 
-        self::$autoloader = (require self::$serverRoot.'/vendor/autoload.php');
+        self::$autoloader = (require self::path('vendor/autoload.php'));
 
-        self::$configDir = self::$serverRoot.'/config';
+        self::$logger = new Logger('logger');
+        self::$logger->pushHandler(new ErrorLogHandler(
+            ErrorLogHandler::OPERATING_SYSTEM,
+            Logger::NOTICE
+        ));
+        ErrorHandler::register(self::$logger);
+
+        self::$configDir = self::path('config');
         self::$config = new \Mesamatrix\Config(self::$configDir);
 
-        date_default_timezone_set('UTC');
-    }
-
-    public static function debug_print($line) {
-        if (self::$config->debug()) {
-            print("DEBUG: ".$line."<br />\n");
+        // register the log file
+        $logLevel = self::$config->getValue('info', 'log_level', Logger::WARNING);
+        self::$logger->popHandler();
+        self::$logger->pushHandler(new StreamHandler(
+            self::path(self::$config->getValue('info', 'private_dir').'/mesamatrix.log'),
+            $logLevel
+        ));
+        if ($logLevel < Logger::INFO) {
+            ini_set('error_reporting', E_ALL);
+            ini_set('display_errors', 1);
         }
+
+        self::$logger->debug('Base initialisation complete');
     }
 
     public static function path($path) {


### PR DESCRIPTION
Some new logging points too.

I tried to keep the chance of failure low - as soon as possible, a Logger is created pointing at the PHP error log. An error handler is also registered at this point, to catch any errors thrown by PHP and forward them to the logs. After the configuration is loaded, the error log handler is unregistered, and a stream handler pointing at `private/mesamatrix.log` is registered. From here on out any log messages go to that file instead of PHP's error log, but in case something during initialisation fails, it gets sent to the error log.

I thought about having configurable log handlers (email for example), but the added complexity wasn't worth it.

As for the console application - no logging to the file is done, but instead all logs just get forwarded to the console.

How to use:

```
\Mesamatrix::$logger->warning('...');
\Mesamatrix::$logger->notice('...');
\Mesamatrix::$logger->error('...');
...
```

Those are probably the most useful log functions, there are more of course.