### PR TITLE
Modified date for GL extensions

### DIFF
--- a/config/config.default.php
+++ b/config/config.default.php
@@ -46,14 +46,15 @@ $CONFIG = array(
     ),
 
     "git" => array(
-        "url" => "git://anongit.freedesktop.org/mesa/mesa",
-        "dir" => "mesa.git",
+        "mesa_web" => "http://cgit.freedesktop.org/mesa/mesa",
+        "mesa_url" => "git://anongit.freedesktop.org/mesa/mesa",
+        "mesa_dir" => "mesa.git",
+
         "depth" => 6000,
         // oldest_commit is based on parser compatibility
         "oldest_commit" => "b6ab52b7f941b689753d4b9af7d58083e6917fd6",
         "commitparser_depth" => 10,
 
-        "web" => "http://cgit.freedesktop.org/mesa/mesa",
         "gl3" => "docs/GL3.txt",
     ),
 );

--- a/http/css/style.css
+++ b/http/css/style.css
@@ -50,7 +50,23 @@ p { max-width: 800px; }
 
 .extension-child { padding-left: 1em; }
 .extension:hover { background-color: #babdb6; }
-.task { border-radius: 4px; padding-right: 4px; text-align: right; }
+.task {
+    position: relative;
+    border-radius: 4px;
+    padding-right: 4px;
+    height: 19px;
+    width: 72px;
+    padding: 0;
+}
+
+.task span {
+    position: absolute;
+    bottom: 0;
+    right: 0;
+    font: 9px sans-serif;
+    text-decoration: none;
+    color: black;
+}
 
 .isDone { background-color: #8ae234; }
 .isInProgress { background-color: #f1922b; }
@@ -60,7 +76,8 @@ p { max-width: 800px; }
 
 .footnote a {
     display: block;
-    text-decoration: none;
+    height: 100%;
+    width: 100%;
 }
 .footnote.task {
     padding:0;

--- a/http/css/style.css
+++ b/http/css/style.css
@@ -63,7 +63,7 @@ p { max-width: 800px; }
     position: absolute;
     bottom: 0;
     right: 0;
-    font: 9px sans-serif;
+    font: 0.7em sans-serif;
     text-decoration: none;
     color: black;
 }

--- a/http/index.php
+++ b/http/index.php
@@ -234,8 +234,8 @@ foreach ($glVersions as $glVersion) {
         }
 
         $cellText = '';
-        if (isset($ext->mesa['modified'])) {
-            $cellText = '<span data-timestamp="' . $ext->mesa['modified'] . '">'.date('Y-m-d', (int) $ext->mesa['modified']).'</span>';
+        if (!empty($ext->mesa->modified)) {
+            $cellText = '<span data-timestamp="' . $ext->mesa->modified->date . '">'.date('Y-m-d', (int) $ext->mesa->modified->date).'</span>';
         }
 
         $extUrlId = $glUrlId."_Extension_".urlencode(str_replace(" ", "", $ext["name"]));
@@ -273,8 +273,8 @@ foreach ($glVersions as $glVersion) {
                     if ($extHintIdx !== -1) {
                         $taskClasses .= " footnote";
                     }
-                    if (isset($driverNode['modified'])) {
-                        $cellText = '<span data-timestamp="' . $driverNode['modified'] . '">'.date('Y-m-d', (int) $driverNode['modified']).'</span>';
+                    if (!empty($driverNode->modified)) {
+                        $cellText = '<span data-timestamp="' . $driverNode->modified->date . '">'.date('Y-m-d', (int) $driverNode->modified->date).'</span>';
                     }
                 }
                 else {

--- a/http/index.php
+++ b/http/index.php
@@ -235,7 +235,7 @@ foreach ($glVersions as $glVersion) {
 
         $cellText = '';
         if (isset($ext->mesa['modified'])) {
-            $cellText = '<span>'.date('Y-m-d', (int) $ext->mesa['modified']).'</span>';
+            $cellText = '<span data-timestamp="' . $ext->mesa['modified'] . '">'.date('Y-m-d', (int) $ext->mesa['modified']).'</span>';
         }
 
         $extUrlId = $glUrlId."_Extension_".urlencode(str_replace(" ", "", $ext["name"]));
@@ -274,7 +274,7 @@ foreach ($glVersions as $glVersion) {
                         $taskClasses .= " footnote";
                     }
                     if (isset($driverNode['modified'])) {
-                        $cellText = '<span>'.date('Y-m-d', (int) $driverNode['modified']).'</span>';
+                        $cellText = '<span data-timestamp="' . $driverNode['modified'] . '">'.date('Y-m-d', (int) $driverNode['modified']).'</span>';
                     }
                 }
                 else {

--- a/http/index.php
+++ b/http/index.php
@@ -91,11 +91,7 @@ $numTotalExts = $leaderboard->getNumTotalExts();
 /////////////////////////////////////////////////
 // Update times.
 //
-$updateTime = filemtime($gl3Path);
-$lastGitUpdate = "No commit found";
-if (count($xml->commits->commit) > 0) {
-    $lastGitUpdate = date(DATE_RFC2822, (int) $xml->commits->commit[0]["timestamp"]);
-}
+$lastGitUpdate = date(DATE_RFC2822, (int) $xml['updated']);
 
 /////////////////////////////////////////////////
 // Drivers CSS classes.

--- a/http/index.php
+++ b/http/index.php
@@ -130,7 +130,7 @@ foreach ($xml->drivers->vendor as $vendor) {
     </head>
     <body>
         <h1>Last commits</h1>
-        <p><b>Last git update:</b> <script>document.write(getLocalDate("<?= $lastGitUpdate ?>"));</script><noscript><?= $lastGitUpdate ?></noscript> (<a href="<?= Mesamatrix::$config->getValue("git", "web")."/log/docs/GL3.txt" ?>">see the log</a>)</p>
+        <p><b>Last git update:</b> <script>document.write(getLocalDate("<?= $lastGitUpdate ?>"));</script><noscript><?= $lastGitUpdate ?></noscript> (<a href="<?= Mesamatrix::$config->getValue("git", "mesa_web")."/log/docs/GL3.txt" ?>">see the log</a>)</p>
         <table class="commits">
             <thead>
                 <tr>
@@ -142,7 +142,7 @@ foreach ($xml->drivers->vendor as $vendor) {
 <?php
 foreach ($xml->commits->commit as $commit) {
     $commitDate = date(DATE_RFC2822, (int) $commit["timestamp"]);
-    $commitUrl = Mesamatrix::$config->getValue("git", "web")."/commit/".Mesamatrix::$config->getValue("git", "gl3")."?id=".$commit["hash"];
+    $commitUrl = Mesamatrix::$config->getValue("git", "mesa_web")."/commit/".Mesamatrix::$config->getValue("git", "gl3")."?id=".$commit["hash"];
 ?>
                 <tr>
                     <td class="commitsAge"><script>document.write(getRelativeDate('<?= $commitDate ?>'));</script><noscript><?= $commitDate ?></noscript></td>
@@ -341,7 +341,7 @@ if (Mesamatrix::$config->getValue("flattr", "enabled")) {
             <li>Wikipedia (en): <a href="https://en.wikipedia.org/wiki/Nouveau_%28software%29" title="Nouveau (software)">Nouveau (software)</a></li>
         </ul>
         <h1>Sources</h1>
-        <p><b>This page is generated from:</b> <a href="<?= Mesamatrix::$config->getValue("git", "web")."/tree/".Mesamatrix::$config->getValue("git", "gl3") ?>"><?= Mesamatrix::$config->getValue("git", "web")."/tree/".Mesamatrix::$config->getValue("git", "gl3") ?></a></p>
+        <p><b>This page is generated from:</b> <a href="<?= Mesamatrix::$config->getValue("git", "mesa_web")."/tree/".Mesamatrix::$config->getValue("git", "gl3") ?>"><?= Mesamatrix::$config->getValue("git", "mesa_web")."/tree/".Mesamatrix::$config->getValue("git", "gl3") ?></a></p>
         <p>If you want to report a bug or simply to participate in the project, feel free to get the sources:
         <a href="<?= Mesamatrix::$config->getValue("info", "project_url") ?>"><?= Mesamatrix::$config->getValue("info", "project_url") ?></a></p>
         <p><a href="https://www.gnu.org/licenses/agpl.html"><img src="https://www.gnu.org/graphics/agplv3-155x51.png" alt="Logo AGPLv3" /></a></p>

--- a/http/js/script.js
+++ b/http/js/script.js
@@ -75,6 +75,10 @@ function getRelativeDate(text) {
     return year + "-" + month + "-" + day;
 }
 
+function gaussian(x, a, b, c) {
+    return a * Math.exp(- Math.pow(x - b, 2) / (2 * Math.pow(c, 2)));
+}
+
 $(document).ready(function() {
     $(".footnote a").tipsy({gravity: "w"});
 //    $(".footnote a").on("click", function(e) {
@@ -85,4 +89,11 @@ $(document).ready(function() {
 //            $(this).tipsy("hide");
 //        }
 //    });
+
+    // adjust the opacity of the 'modified' text based on age
+    var timeConst = 1.2e7;
+    $('.task span').each(function() {
+        var timeDiff = (Date.now()/1000) - $(this).data('timestamp');
+        $(this).css('opacity', gaussian(timeDiff, 1, 0, timeConst));
+    });
 });

--- a/lib/Config.php
+++ b/lib/Config.php
@@ -43,6 +43,13 @@ class Config
                 return $this->cache[$section][$key];
             }
         }
+        $logMsg = 'Unable to find config value for '.$section.'.'.$key;
+        if (is_null($default)) {
+            \Mesamatrix::$logger->error($logMsg);
+        }
+        else {
+            \Mesamatrix::$logger->info($logMsg.', using default '.$default);
+        }
         return $default;
     }
 

--- a/lib/Console/Command/Parse.php
+++ b/lib/Console/Command/Parse.php
@@ -66,6 +66,11 @@ class Parse extends \Symfony\Component\Console\Command\Command
 
         $xml = new \SimpleXMLElement("<mesa></mesa>");
 
+        $gitDir = \Mesamatrix::path(\Mesamatrix::$config->getValue('info', 'private_dir')).'/';
+        $gitDir .= \Mesamatrix::$config->getValue('git', 'mesa_dir', 'mesa.git');
+        $updated = filemtime($gitDir . '/FETCH_HEAD');
+        $xml->addAttribute('updated', $updated);
+
         $drivers = $xml->addChild("drivers");
         $this->populateDrivers($drivers);
 

--- a/lib/Console/Command/Parse.php
+++ b/lib/Console/Command/Parse.php
@@ -51,6 +51,7 @@ class Parse extends \Symfony\Component\Console\Command\Command
         $commitLines = explode(PHP_EOL, $gitLogProc->getOutput());
         $hints = new Hints();
         $matrix = new \Mesamatrix\Parser\OglMatrix();
+        $parser = new \Mesamatrix\Parser\OglParser($hints, $matrix);
         foreach ($commitLines as $commitLine) {
             list($commitHash, $time, $author, $committer) = explode('|', $commitLine);
             $commit = new \Mesamatrix\Git\Commit($commitHash, $time, $author, $committer);
@@ -61,8 +62,7 @@ class Parse extends \Symfony\Component\Console\Command\Command
             $proc = $cat->getProcess();
             $this->getHelper('process')->mustRun($output, $proc);
 
-            $parser = new \Mesamatrix\Parser\OglParser($hints, $matrix, $commit);
-            $parser->parse_content($proc->getOutput());
+            $parser->parse_content($proc->getOutput(), $commit);
         }
 
         $xml = new \SimpleXMLElement("<mesa></mesa>");

--- a/lib/Console/Command/Parse.php
+++ b/lib/Console/Command/Parse.php
@@ -23,149 +23,74 @@ namespace Mesamatrix\Console\Command;
 
 use \Symfony\Component\Console\Input\InputInterface;
 use \Symfony\Component\Console\Output\OutputInterface;
+use \Mesamatrix\Parser\OglVersion;
+use \Mesamatrix\Parser\UrlCache;
+use \Mesamatrix\Parser\Hints;
 
 class Parse extends \Symfony\Component\Console\Command\Command
 {
-    protected function configure()
-    {
+    protected $urlCache;
+    protected $statuses;
+
+    protected function configure() {
         $this->setName('parse')
              ->setDescription('Parse data and generate XML')
         ;
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
-    {
-        //$gitLog = exec_git("log --pretty=format:%H --reverse " .
-        //    Mesamatrix::$config->getValue("git", "oldest_commit").".. -- ".Mesamatrix::$config->getValue("git", "gl3"), $log);
-        //$initialCommit = rtrim(fgets($log));
-        $initialCommit = "master";
-
-        $cat = new \Mesamatrix\Git\ProcessBuilder(array(
-          'show', $initialCommit.':'.\Mesamatrix::$config->getValue('git', 'gl3')
+    protected function execute(InputInterface $input, OutputInterface $output) {
+        $gl3Path = \Mesamatrix::$config->getValue('git', 'gl3', 'docs/GL3.txt');
+        $gitLog = new \Mesamatrix\Git\ProcessBuilder(array(
+            'log', '--pretty=format:%H:%at', '--reverse',
+            \Mesamatrix::$config->getValue('git', 'oldest_commit').'..', '--',
+            $gl3Path
         ));
-        $proc = $cat->getProcess();
-        $this->getHelper('process')->mustRun($output, $proc);
+        $gitLogProc = $gitLog->getProcess();
+        $this->getHelper('process')->mustRun($output, $gitLogProc);
 
-        $hints = new \Mesamatrix\Parser\Hints();
-        $parser = new \Mesamatrix\Parser\OglParser($hints);
-        $matrix = $parser->parse_content($proc->getOutput());
+        $commitLines = explode(PHP_EOL, $gitLogProc->getOutput());
+        $hints = new Hints();
+        $matrix = new \Mesamatrix\Parser\OglMatrix();
+        foreach ($commitLines as $commitLine) {
+            list($commit, $time) = explode(':', $commitLine);
+            \Mesamatrix::$logger->info('Parsing GL3.txt for commit '.$commit);
+            $cat = new \Mesamatrix\Git\ProcessBuilder(array(
+              'show', $commit.':'.$gl3Path
+            ));
+            $proc = $cat->getProcess();
+            $this->getHelper('process')->mustRun($output, $proc);
+
+            $parser = new \Mesamatrix\Parser\OglParser($hints, $matrix, $time);
+            $parser->parse_content($proc->getOutput());
+        }
 
         $xml = new \SimpleXMLElement("<mesa></mesa>");
 
-        // driver definitions
         $drivers = $xml->addChild("drivers");
-        foreach (\Mesamatrix\Parser\Constants::$allDriversVendors as $glVendor => $glDrivers) {
-            $vendor = $drivers->addChild("vendor");
-            $vendor->addAttribute("name", $glVendor);
-            foreach ($glDrivers as $glDriver) {
-                $driver = $vendor->addChild("driver");
-                $driver->addAttribute("name", $glDriver);
-            }
-        }
+        $this->populateDrivers($drivers);
 
-        // commits log
-        $gitLogFormat = "%H%n  timestamp: %ct%n  author: %an%n  subject: %s%n";
-        $gitCommits = new \Mesamatrix\Git\ProcessBuilder(array(
-          'log', '-n', \Mesamatrix::$config->getValue('git', 'commitparser_depth', 10),
-          '--pretty=format:'.$gitLogFormat, '--',
-          \Mesamatrix::$config->getValue('git', 'gl3', 'docs/GL3.txt')
-        ));
-        $proc = $gitCommits->getProcess();
-        $this->getHelper('process')->mustRun($output, $proc);
+        $xmlCommits = $xml->addChild('commits');
+        $this->generateCommitsLog($xmlCommits, $gl3Path, $output);
 
-        $commitsParser = new \Mesamatrix\CommitsParser();
-        $commits = $commitsParser->parse_content($proc->getOutput());
-
-        $xmlCommits = $xml->addChild("commits");
-        foreach ($commits as $gitCommit) {
-            \Mesamatrix::$logger->debug('Processing commit '.$gitCommit["hash"]);
-            $commit = $xmlCommits->addChild("commit");
-            $commit->addAttribute("hash", $gitCommit["hash"]);
-            $commit->addAttribute("timestamp", $gitCommit["timestamp"]);
-            $commit->addAttribute("subject", $gitCommit["subject"]);
-        }
-
-        // status definitions
-        $statuses = $xml->addChild("statuses");
-
-        $complete = $statuses->addChild("complete");
-        $complete->addChild("match", "DONE*");
-
-        $incomplete = $statuses->addChild("incomplete");
-        $incomplete->addChild("match", "not started*");
-
-        $inProgressStatus = $statuses->addChild("started");
-        $inProgressStatus->addChild("match", "*");
+        $this->statuses = $xml->addChild("statuses");
+        $this->populateStatuses($this->statuses);
 
         // Need URL cache?
-        $urlCache = NULL;
+        $this->urlCache = NULL;
         if(\Mesamatrix::$config->getValue("opengl_links", "enabled", false)) {
             // Load URL cache.
-            $urlCache = new \Mesamatrix\Parser\UrlCache();
-            $urlCache->load();
+            $this->urlCache = new UrlCache();
+            $this->urlCache->load();
         }
 
         // extensions
         foreach ($matrix->getGlVersions() as $glVersion) {
-            $gl = $xml->addChild("gl");
-            $gl->addAttribute("name", $glVersion->getGlName());
-            $gl->addAttribute("version", $glVersion->getGlVersion());
-            $glsl = $gl->addChild("glsl");
-            $glsl->addAttribute("name", $glVersion->getGlslName());
-            $glsl->addAttribute("version", $glVersion->getGlslVersion());
-
-            foreach ($glVersion->getExtensions() as $glExt) {
-                \Mesamatrix::$logger->debug('Processing extension '.$glExt->getName());
-                $ext = $gl->addChild("extension");
-                $ext->addAttribute("name", $glExt->getName());
-
-                if ($urlCache) {
-                    if (preg_match("/(GLX?)_([^_]+)_([a-zA-Z0-9_]+)/", $glExt->getName(), $matches) === 1) {
-                        $openglUrl = \Mesamatrix::$config->getValue("opengl_links", "url").urlencode($matches[2])."/";
-                        if ($matches[1] === "GL") {
-                            // Found a GL_TYPE_extension.
-                            $openglUrl .= urlencode($matches[3]).".txt";
-                        }
-                        else {
-                            // Found a GLX_TYPE_Extension.
-                            $openglUrl .= "glx_".urlencode($matches[3]).".txt";
-                        }
-
-                        if ($urlCache->isValid($openglUrl)) {
-                            $linkNode = $ext->addChild("link", $matches[0]);
-                            $linkNode->addAttribute("href", $openglUrl);
-                        }
-                    }
-                }
-
-                $mesaStatus = $ext->addChild("mesa");
-                $statusLength = 0;
-                foreach ($statuses as $matchStatus) {
-                    foreach ($matchStatus as $match) {
-                        if (fnmatch($match, $glExt->getStatus()) && strlen($match) >= $statusLength) {
-                            $mesaStatus->addAttribute("status", $matchStatus->getName());
-                            $statusLength = strlen($match);
-                        }
-                    }
-                }
-                $mesaHintId = $glExt->getHintIdx();
-                if ($mesaHintId !== -1) {
-                    $mesaStatus->addAttribute("hint", $hints->allHints[$mesaHintId]);
-                }
-
-                $supported = $ext->addChild("supported");
-                foreach ($glExt->getSupportedDrivers() as $glDriver) {
-                    $driver = $supported->addChild($glDriver->getName());
-                    $hintId = $glDriver->getHintIdx();
-                    if ($hintId !== -1) {
-                        $driver->addAttribute("hint", $hints->allHints[$hintId]);
-                    }
-                }
-            }
+            $gl = $xml->addChild('gl');
+            $this->generateGlSection($gl, $glVersion, $hints);
         }
 
-        if ($urlCache) {
-            $urlCache->save();
+        if ($this->urlCache) {
+            $this->urlCache->save();
         }
 
         $xmlPath = \Mesamatrix::path(\Mesamatrix::$config->getValue("info", "xml_file"));
@@ -176,5 +101,112 @@ class Parse extends \Symfony\Component\Console\Command\Command
         file_put_contents($xmlPath, $dom->saveXML());
         //$xml->asXML($xmlPath);
         \Mesamatrix::$logger->notice('XML saved to '.$xmlPath);
+    }
+
+    protected function populateDrivers(\SimpleXMLElement $drivers) {
+        foreach (\Mesamatrix\Parser\Constants::$allDriversVendors as $glVendor => $glDrivers) {
+            $vendor = $drivers->addChild("vendor");
+            $vendor->addAttribute("name", $glVendor);
+            foreach ($glDrivers as $glDriver) {
+                $driver = $vendor->addChild("driver");
+                $driver->addAttribute("name", $glDriver);
+            }
+        }
+    }
+
+    protected function populateStatuses(\SimpleXMLElement $statuses) {
+        $complete = $statuses->addChild("complete");
+        $complete->addChild("match", "DONE*");
+
+        $incomplete = $statuses->addChild("incomplete");
+        $incomplete->addChild("match", "not started*");
+
+        $inProgressStatus = $statuses->addChild("started");
+        $inProgressStatus->addChild("match", "*");
+    }
+
+    protected function generateCommitsLog(\SimpleXMLElement $xml, $gl3Path, OutputInterface $output) {
+        $gitLogFormat = "%H%n  timestamp: %ct%n  author: %an%n  subject: %s%n";
+        $gitCommits = new \Mesamatrix\Git\ProcessBuilder(array(
+          'log', '-n', \Mesamatrix::$config->getValue('git', 'commitparser_depth', 10),
+          '--pretty=format:'.$gitLogFormat, '--',
+          $gl3Path
+        ));
+        $proc = $gitCommits->getProcess();
+        $this->getHelper('process')->mustRun($output, $proc);
+
+        $commitsParser = new \Mesamatrix\CommitsParser();
+        $commits = $commitsParser->parse_content($proc->getOutput());
+
+        foreach ($commits as $gitCommit) {
+            \Mesamatrix::$logger->debug('Processing commit '.$gitCommit["hash"]);
+            $commit = $xml->addChild("commit");
+            $commit->addAttribute("hash", $gitCommit["hash"]);
+            $commit->addAttribute("timestamp", $gitCommit["timestamp"]);
+            $commit->addAttribute("subject", $gitCommit["subject"]);
+        }
+    }
+
+    protected function generateGlSection(\SimpleXMLElement $gl, OglVersion $glVersion, Hints $hints) {
+        $gl->addAttribute("name", $glVersion->getGlName());
+        $gl->addAttribute("version", $glVersion->getGlVersion());
+        $glsl = $gl->addChild("glsl");
+        $glsl->addAttribute("name", $glVersion->getGlslName());
+        $glsl->addAttribute("version", $glVersion->getGlslVersion());
+
+        foreach ($glVersion->getExtensions() as $glExt) {
+            \Mesamatrix::$logger->debug('Processing extension '.$glExt->getName());
+            $ext = $gl->addChild("extension");
+            $ext->addAttribute("name", $glExt->getName());
+
+            if ($this->urlCache) {
+                if (preg_match("/(GLX?)_([^_]+)_([a-zA-Z0-9_]+)/", $glExt->getName(), $matches) === 1) {
+                    $openglUrl = \Mesamatrix::$config->getValue("opengl_links", "url").urlencode($matches[2])."/";
+                    if ($matches[1] === "GL") {
+                        // Found a GL_TYPE_extension.
+                        $openglUrl .= urlencode($matches[3]).".txt";
+                    }
+                    else {
+                        // Found a GLX_TYPE_Extension.
+                        $openglUrl .= "glx_".urlencode($matches[3]).".txt";
+                    }
+
+                    if ($this->urlCache->isValid($openglUrl)) {
+                        $linkNode = $ext->addChild("link", $matches[0]);
+                        $linkNode->addAttribute("href", $openglUrl);
+                    }
+                }
+            }
+
+            $mesaStatus = $ext->addChild("mesa");
+            $statusLength = 0;
+            foreach ($this->statuses as $matchStatus) {
+                foreach ($matchStatus as $match) {
+                    if (fnmatch($match, $glExt->getStatus()) && strlen($match) >= $statusLength) {
+                        $mesaStatus->addAttribute("status", $matchStatus->getName());
+                        $statusLength = strlen($match);
+                    }
+                }
+            }
+            $mesaHintId = $glExt->getHintIdx();
+            if ($mesaHintId !== -1) {
+                $mesaStatus->addAttribute("hint", $hints->allHints[$mesaHintId]);
+            }
+            if ($time = $glExt->getLastModified()) {
+                $mesaStatus->addAttribute("modified", $time);
+            }
+
+            $supported = $ext->addChild("supported");
+            foreach ($glExt->getSupportedDrivers() as $glDriver) {
+                $driver = $supported->addChild($glDriver->getName());
+                $hintId = $glDriver->getHintIdx();
+                if ($hintId !== -1) {
+                    $driver->addAttribute("hint", $hints->allHints[$hintId]);
+                }
+                if ($time = $glDriver->getLastModified()) {
+                    $driver->addAttribute("modified", $time);
+                }
+            }
+        }
     }
 }

--- a/lib/Console/Command/Setup.php
+++ b/lib/Console/Command/Setup.php
@@ -37,7 +37,7 @@ class Setup extends \Symfony\Component\Console\Command\Command
     {
         $git = new \Mesamatrix\Git\ProcessBuilder(array(
           'clone', '--bare', '--depth', \Mesamatrix::$config->getValue('git', 'depth', 6000),
-          \Mesamatrix::$config->getValue('git', 'url'), '@gitDir@'
+          \Mesamatrix::$config->getValue('git', 'mesa_url'), '@gitDir@'
         ));
         $this->getHelper('process')->mustRun($output, $git->getProcess());
     }

--- a/lib/Git/Commit.php
+++ b/lib/Git/Commit.php
@@ -1,0 +1,88 @@
+<?php
+/*
+ * This file is part of mesamatrix.
+ *
+ * Copyright (C) 2015 Robin McCorkell <rmccorkell@karoshi.org.uk>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace Mesamatrix\Git;
+
+class Commit
+{
+    private $hash;
+    private $date;
+    private $author;
+    private $committer;
+
+    public function __construct($hash, $date, $author, $committer = null)
+    {
+        $this->setHash($hash);
+        $this->setDate($date);
+        $this->setAuthor($author);
+        $this->setCommitter(isset($committer) ? $committer : $author);
+    }
+
+    public function getHash()
+    {
+        return $this->hash;
+    }
+
+    public function setHash($hash)
+    {
+        $this->hash = $hash;
+    }
+
+    public function getDate()
+    {
+        return $this->date;
+    }
+
+    public function setDate($date)
+    {
+        if (is_numeric($date)) {
+            $this->setDateString('@'.$date);
+        } elseif (is_string($date)) {
+            $this->setDateString($date);
+        } else {
+            $this->date = $date;
+        }
+    }
+
+    public function setDateString($date, $timezone = null)
+    {
+        $this->setDate(new \DateTime($date, $timezone));
+    }
+
+    public function getAuthor()
+    {
+        return $this->author;
+    }
+
+    public function setAuthor($author)
+    {
+        $this->author = $author;
+    }
+
+    public function getCommitter()
+    {
+        return $this->committer;
+    }
+
+    public function setCommitter($committer)
+    {
+        $this->committer = $committer;
+    }
+}

--- a/lib/Git/ProcessBuilder.php
+++ b/lib/Git/ProcessBuilder.php
@@ -27,7 +27,7 @@ class ProcessBuilder extends \Symfony\Component\Process\ProcessBuilder
     {
         array_unshift($arguments, 'git');
         $gitDir = \Mesamatrix::path(\Mesamatrix::$config->getValue("info", "private_dir"))."/";
-        $gitDir .= \Mesamatrix::$config->getValue("git", "dir", "mesa.git");
+        $gitDir .= \Mesamatrix::$config->getValue("git", "mesa_dir", "mesa.git");
         foreach ($arguments as &$arg) {
             $arg = str_replace('@gitDir@', $gitDir, $arg);
         }

--- a/lib/Parser/OglExtension.php
+++ b/lib/Parser/OglExtension.php
@@ -23,12 +23,12 @@ namespace Mesamatrix\Parser;
 class OglExtension
 {
     public function __construct($name, $status, $hints, $supportedDrivers = array()) {
-        $this->name = $name;
-        $this->hints = $hints;
-        $this->supportedDrivers = array();
-        $this->modifiedAt = null;
-
+        $this->setName($name);
         $this->setStatus($status);
+        $this->hints = $hints;
+        $this->setModifiedAt(null);
+
+        $this->supportedDrivers = array();
         foreach ($supportedDrivers as $driverName) {
             $this->addSupportedDriver($driverName);
         }

--- a/lib/Parser/OglExtension.php
+++ b/lib/Parser/OglExtension.php
@@ -26,7 +26,7 @@ class OglExtension
         $this->name = $name;
         $this->hints = $hints;
         $this->supportedDrivers = array();
-        $this->lastModified = null;
+        $this->modifiedAt = null;
 
         $this->setStatus($status);
         foreach ($supportedDrivers as $driverName) {
@@ -73,8 +73,8 @@ class OglExtension
     }
 
     // supported drivers
-    public function addSupportedDriver($driverName, $time = null) {
-        $this->supportedDrivers[] = new OglSupportedDriver($driverName, $this->hints, $time);
+    public function addSupportedDriver($driverName, $commit = null) {
+        $this->supportedDrivers[] = new OglSupportedDriver($driverName, $this->hints, $commit);
     }
     public function getSupportedDrivers() {
         return $this->supportedDrivers;
@@ -88,33 +88,33 @@ class OglExtension
         }
     }
 
-    // last modified
-    public function setLastModified($time) {
-        $this->lastModified = $time;
+    // modified at
+    public function setModifiedAt($commit) {
+        $this->modifiedAt = $commit;
     }
-    public function getLastModified() {
-        return $this->lastModified;
+    public function getModifiedAt() {
+        return $this->modifiedAt;
     }
 
     // merge
-    public function incorporate($other, $time) {
+    public function incorporate($other, $commit) {
         if ($this->name !== $other->name) {
             \Mesamatrix::$logger->error('Merging extensions with different names');
         }
         if ($this->status !== $other->status) {
             $this->status = $other->status;
-            $this->setLastModified($time);
+            $this->setModifiedAt($commit);
         }
         if ($this->hintIdx !== $other->hintIdx) {
             $this->hintIdx = $other->hintIdx;
-            $this->setLastModified($time);
+            $this->setModifiedAt($commit);
         }
         foreach ($other->supportedDrivers as $supportedDriver) {
             if ($driver = $this->getSupportedDriverByName($supportedDriver->getName())) {
-                $driver->incorporate($supportedDriver, $time);
+                $driver->incorporate($supportedDriver, $commit);
             }
             else {
-                $supportedDriver->setLastModified($time);
+                $supportedDriver->setModifiedAt($commit);
                 $this->supportedDrivers[] = $supportedDriver;
             }
         }
@@ -125,5 +125,5 @@ class OglExtension
     private $hints;
     private $hintIdx;
     private $supportedDrivers;
-    private $lastModified;
+    private $modifiedAt;
 };

--- a/lib/Parser/OglMatrix.php
+++ b/lib/Parser/OglMatrix.php
@@ -34,5 +34,15 @@ class OglMatrix
         return $this->glVersions;
     }
 
+    public function getGlVersionByName($name, $version) {
+        foreach ($this->glVersions as $glVersion) {
+            if ($glVersion->getGlName() === 'Open'.$name
+             && $glVersion->getGlVersion() === $version) {
+                return $glVersion;
+            }
+        }
+        return null;
+    }
+
     private $glVersions;
 };

--- a/lib/Parser/OglParser.php
+++ b/lib/Parser/OglParser.php
@@ -24,35 +24,31 @@ class OglParser
 {
     private $hints;
     private $matrix;
-    private $commit;
 
-    public function __construct($hints, $matrix, $commit = null) {
+    public function __construct($hints, $matrix) {
         $this->hints = $hints;
         $this->matrix = $matrix;
-        $this->commit = $commit;
     }
 
-    public function parse($filename) {
+    public function parse($filename, $commit = null) {
         $handle = fopen($filename, "r");
         if ($handle === FALSE) {
             return NULL;
         }
 
-        $ret = $this->parse_stream($handle);
+        $this->parse_stream($handle, $commit);
         fclose($handle);
-        return $ret;
     }
 
-    public function parse_content($content) {
+    public function parse_content($content, $commit = null) {
         $handle = fopen("php://memory", "r+");
         fwrite($handle, $content);
         rewind($handle);
-        $ret = $this->parse_stream($handle);
+        $this->parse_stream($handle, $commit);
         fclose($handle);
-        return $ret;
     }
 
-    public function parse_stream($handle) {
+    public function parse_stream($handle, $commit = null) {
         // Regexp patterns.
         $reTableHeader = "/^Feature([ ]+)Status/";
         $reVersion = "/^(GL(ES)?) ?([[:digit:]]+\.[[:digit:]]+), (GLSL( ES)?) ([[:digit:]]+\.[[:digit:]]+)/";
@@ -124,7 +120,7 @@ class OglParser
                             $parentDrivers = $supportedDrivers;
                         }
 
-                        $glVersion->addExtension($matches[1], $matches[2], $supportedDrivers, $this->commit);
+                        $glVersion->addExtension($matches[1], $matches[2], $supportedDrivers, $commit);
                     }
 
                     $line = fgets($handle);
@@ -145,8 +141,6 @@ class OglParser
                 $line = fgets($handle);
             }
         }
-
-        return $this->matrix;
     }
 
     private function skipEmptyLines($curLine, $handle) {

--- a/lib/Parser/OglParser.php
+++ b/lib/Parser/OglParser.php
@@ -24,12 +24,12 @@ class OglParser
 {
     private $hints;
     private $matrix;
-    private $time;
+    private $commit;
 
-    public function __construct($hints, $matrix, $time = null) {
+    public function __construct($hints, $matrix, $commit = null) {
         $this->hints = $hints;
         $this->matrix = $matrix;
-        $this->time = $time;
+        $this->commit = $commit;
     }
 
     public function parse($filename) {
@@ -124,7 +124,7 @@ class OglParser
                             $parentDrivers = $supportedDrivers;
                         }
 
-                        $glVersion->addExtension($matches[1], $matches[2], $supportedDrivers, $this->time);
+                        $glVersion->addExtension($matches[1], $matches[2], $supportedDrivers, $this->commit);
                     }
 
                     $line = fgets($handle);

--- a/lib/Parser/OglSupportedDriver.php
+++ b/lib/Parser/OglSupportedDriver.php
@@ -23,9 +23,11 @@ namespace Mesamatrix\Parser;
 class OglSupportedDriver
 {
     public function __construct($name, $hints) {
-        $this->name = "<undefined>";
+        $this->setName("<undefined>");
         $this->hints = $hints;
         $this->hintIdx = -1;
+        $this->lastModified = null;
+
         foreach (Constants::$allDrivers as $driver) {
             $driverLen = strlen($driver);
             if (strncmp($name, $driver, $driverLen) === 0) {
@@ -35,13 +37,43 @@ class OglSupportedDriver
         }
     }
 
-    public function setName($name) { $this->name = $name; }
-    public function getName()      { return $this->name; }
+    // hints
+    public function setName($name) {
+        $this->name = $name;
+    }
+    public function getName() {
+        return $this->name;
+    }
 
-    public function setHint($hint) { $this->hintIdx = $this->hints->addToHints($hint); }
-    public function getHintIdx()   { return $this->hintIdx; }
+    // hints
+    public function setHint($hint) {
+        $this->hintIdx = $this->hints->addToHints($hint);
+    }
+    public function getHintIdx() {
+        return $this->hintIdx;
+    }
+
+    // last modified
+    public function setLastModified($time) {
+        $this->lastModified = $time;
+    }
+    public function getLastModified() {
+        return $this->lastModified;
+    }
+
+    // merge
+    public function incorporate($other, $time) {
+        if ($this->name !== $other->name) {
+            \Mesamatrix::$logger->error('Merging supported drivers with different names');
+        }
+        if ($this->hintIdx !== $other->hintIdx) {
+            $this->hintIdx = $other->hintIdx;
+            $this->setLastModified($time);
+        }
+    }
 
     private $name;
     private $hints;
     private $hintIdx;
+    private $lastModified;
 };

--- a/lib/Parser/OglSupportedDriver.php
+++ b/lib/Parser/OglSupportedDriver.php
@@ -26,7 +26,7 @@ class OglSupportedDriver
         $this->setName("<undefined>");
         $this->hints = $hints;
         $this->hintIdx = -1;
-        $this->lastModified = null;
+        $this->modifiedAt = null;
 
         foreach (Constants::$allDrivers as $driver) {
             $driverLen = strlen($driver);
@@ -53,27 +53,27 @@ class OglSupportedDriver
         return $this->hintIdx;
     }
 
-    // last modified
-    public function setLastModified($time) {
-        $this->lastModified = $time;
+    // modified at
+    public function setModifiedAt($commit) {
+        $this->modifiedAt = $commit;
     }
-    public function getLastModified() {
-        return $this->lastModified;
+    public function getModifiedAt() {
+        return $this->modifiedAt;
     }
 
     // merge
-    public function incorporate($other, $time) {
+    public function incorporate($other, $commit) {
         if ($this->name !== $other->name) {
             \Mesamatrix::$logger->error('Merging supported drivers with different names');
         }
         if ($this->hintIdx !== $other->hintIdx) {
             $this->hintIdx = $other->hintIdx;
-            $this->setLastModified($time);
+            $this->setModifiedAt($commit);
         }
     }
 
     private $name;
     private $hints;
     private $hintIdx;
-    private $lastModified;
+    private $modifiedAt;
 };

--- a/lib/Parser/OglSupportedDriver.php
+++ b/lib/Parser/OglSupportedDriver.php
@@ -26,7 +26,7 @@ class OglSupportedDriver
         $this->setName("<undefined>");
         $this->hints = $hints;
         $this->hintIdx = -1;
-        $this->modifiedAt = null;
+        $this->setModifiedAt(null);
 
         foreach (Constants::$allDrivers as $driver) {
             $driverLen = strlen($driver);

--- a/lib/Parser/OglVersion.php
+++ b/lib/Parser/OglVersion.php
@@ -24,9 +24,9 @@ class OglVersion
 {
     public function __construct($glName, $glVersion, $glslName, $glslVersion, $hints) {
         $this->setGlName($glName);
-        $this->glVersion = $glVersion;
-        $this->glslName = $glslName;
-        $this->glslVersion = $glslVersion;
+        $this->setGlVersion($glVersion);
+        $this->setGlslName($glslName);
+        $this->setGlslVersion($glslVersion);
         $this->hints = $hints;
         $this->extensions = array();
     }

--- a/lib/Parser/OglVersion.php
+++ b/lib/Parser/OglVersion.php
@@ -64,10 +64,10 @@ class OglVersion
     }
 
     // GL/GLSL extensions.
-    public function addExtension($name, $status, $supportedDrivers = array(), $time = null) {
+    public function addExtension($name, $status, $supportedDrivers = array(), $commit = null) {
         $newExtension = new OglExtension($name, $status, $this->hints, $supportedDrivers);
         if ($extension = $this->getExtensionByName($name)) {
-            $extension->incorporate($newExtension, $time);
+            $extension->incorporate($newExtension, $commit);
         }
         else {
             $this->extensions[] = $newExtension;

--- a/lib/Parser/OglVersion.php
+++ b/lib/Parser/OglVersion.php
@@ -31,24 +31,61 @@ class OglVersion
         $this->extensions = array();
     }
 
-    /// GL name and version.
-    public function setGlName($name)       { $this->glName = "Open".$name; }
-    public function getGlName()            { return $this->glName; }
-    public function setGlVersion($version) { $this->glVersion = $version; }
-    public function getGlVersion()         { return $this->glVersion; }
-
-    /// GLSL name and version.
-    public function setGlslName($name)       { $this->glslName = $name; }
-    public function getGlslName()            { return $this->glslName; }
-    public function setGlslVersion($version) { $this->glslVersion = $version; }
-    public function getGlslVersion()         { return $this->glslVersion; }
-
-    /// GL/GLSL extensions.
-    public function addExtension($name, $status, $supportedDrivers = array()) {
-        $this->extensions[] = new OglExtension($name, $status, $this->hints, $supportedDrivers);
+    // GL name
+    public function setGlName($name) {
+        $this->glName = "Open".$name;
+    }
+    public function getGlName() {
+        return $this->glName;
     }
 
-    public function getExtensions() { return $this->extensions; }
+    // GL version
+    public function setGlVersion($version) {
+        $this->glVersion = $version;
+    }
+    public function getGlVersion() {
+        return $this->glVersion;
+    }
+
+    // GLSL name
+    public function setGlslName($name) {
+        $this->glslName = $name;
+    }
+    public function getGlslName() {
+        return $this->glslName;
+    }
+
+    // GLSL version
+    public function setGlslVersion($version) {
+        $this->glslVersion = $version;
+    }
+    public function getGlslVersion() {
+        return $this->glslVersion;
+    }
+
+    // GL/GLSL extensions.
+    public function addExtension($name, $status, $supportedDrivers = array(), $time = null) {
+        $newExtension = new OglExtension($name, $status, $this->hints, $supportedDrivers);
+        if ($extension = $this->getExtensionByName($name)) {
+            $extension->incorporate($newExtension, $time);
+        }
+        else {
+            $this->extensions[] = $newExtension;
+        }
+    }
+
+    public function getExtensions() {
+        return $this->extensions;
+    }
+
+    public function getExtensionByName($name) {
+        foreach ($this->extensions as $extension) {
+            if ($extension->getName() === $name) {
+                return $extension;
+            }
+        }
+        return null;
+    }
 
     private $glName;
     private $glVersion;


### PR DESCRIPTION
This PR introduces showing the modification date of an extension, when it was completed, or when its status changed etc. This means that generating gl3.xml now requires parsing each version of GL3.txt since oldest_commit, which is about 30 versions at the moment, but it is very quick anyway (URL checking takes an order of magnitude longer, at least without the cache). I don't think caching will be required just yet.

In addition, there are some miscellaneous changes, like a slight config cleanup to make the keys more explicit ('git.dir' => 'git.mesa_dir', etc) in case we need to use similar keys for other things (a local git repo to keep track of gl3.xml versions, perhaps?). I also modified the 'Last git update' display, so that it truly displays the last git update time and not just the time of the last commit.