### PR TITLE
[Experimental] Change 'not started' colour to grey

### DIFF
--- a/http/css/style.css
+++ b/http/css/style.css
@@ -70,7 +70,7 @@ p { max-width: 800px; }
 
 .isDone { background-color: #8ae234; }
 .isInProgress { background-color: #f1922b; }
-.isNotStarted { background-color: #ef2929; }
+.isNotStarted { background-color: #bababa; }
 
 .permalink:link { text-decoration: none; color: #DDDDDD; }
 
@@ -89,6 +89,6 @@ p { max-width: 800px; }
     background: repeating-linear-gradient(45deg, #f1922b, #f1922b 10px, #d1720b 10px, #d1720b 20px);
 }
 .footnote.isNotStarted {
-    background: repeating-linear-gradient(45deg, #ef2929, #ef2929 10px, #cf0909 10px, #cf0909 20px);
+    background: repeating-linear-gradient(45deg, #bababa, #bababa 10px, #909090 10px, #909089 20px);
 }
 


### PR DESCRIPTION
An experiment in getting rid of the aggressive colours. This has the advantage of displaying the complete and in progress extensions more visibly, without washing them away in a sea of red.

We don't actually use footnotes for incomplete extensions, but I modified some cells to show the colours in the screenshot below:

![screenshot - 270315 - 15 04 01](https://cloud.githubusercontent.com/assets/2016878/6870227/86dea6e2-d492-11e4-90de-7327ea17696b.png)

What do you think @MightyCreak ?