### PR TITLE
Add a flexbox for commits and leaderboard.

### DIFF
--- a/http/css/style.css
+++ b/http/css/style.css
@@ -21,12 +21,20 @@ body { font-size: 85%; font-family: sans-serif; }
 
 p { max-width: 800px; }
 
+.stats {
+    display: flex;
+}
+
+.stats-lb {
+    margin-left: 40px;
+}
+
 .commits th                         { text-align: left; }
 .commits .commitsAge                { padding-right: 2em; }
 .commits .commitsAge::first-letter  { text-transform: uppercase; }
 
 .lb                             { border-collapse: collapse; border-spacing: 0; }
-.lb th, .lb td                  { padding: 0.1em 0.5em; }
+.lb th, .lb td                  { padding: 0.25em 0.5em; }
 .lb th                          { background-color: #d3d7cf; }
 .lb td                          { border: 1px solid #d3d7cf; }
 .lbCol-rank                     { text-align: center; }

--- a/http/index.php
+++ b/http/index.php
@@ -306,56 +306,62 @@ foreach ($xml->drivers->vendor as $vendor) {
         <script src="js/script.js"></script>
     </head>
     <body>
-        <h1>Last commits</h1>
-        <p><b>Last git update:</b> <?= writeLocalDate($xml['updated']) ?> (<a href="<?= Mesamatrix::$config->getValue("git", "mesa_web")."/log/docs/GL3.txt" ?>">see the log</a>)</p>
-        <table class="commits">
-            <thead>
-                <tr>
-                    <th>Age</th>
-                    <th>Commit message</th>
-                </tr>
-            </thead>
-            <tbody>
+        <div class="stats">
+            <div class="stats-commits">
+                <h1>Last commits</h1>
+                <p><b>Last git update:</b> <?= writeLocalDate($xml['updated']) ?> (<a href="<?= Mesamatrix::$config->getValue("git", "mesa_web")."/log/docs/GL3.txt" ?>">see the log</a>)</p>
+                <table class="commits">
+                    <thead>
+                        <tr>
+                            <th>Age</th>
+                            <th>Commit message</th>
+                        </tr>
+                    </thead>
+                    <tbody>
 <?php
 foreach ($xml->commits->commit as $commit) {
     $commitUrl = Mesamatrix::$config->getValue("git", "mesa_web")."/commit/".Mesamatrix::$config->getValue("git", "gl3")."?id=".$commit["hash"];
 ?>
-                <tr>
-                    <td class="commitsAge"><?= writeRelativeDate($commit['timestamp']) ?></td>
-                    <td><a href="<?= $commitUrl ?>"><?= $commit["subject"] ?></a></td>
-                </tr>
+                        <tr>
+                            <td class="commitsAge"><?= writeRelativeDate($commit['timestamp']) ?></td>
+                            <td><a href="<?= $commitUrl ?>"><?= $commit["subject"] ?></a></td>
+                        </tr>
 <?php
 }
 ?>
-            </tbody>
-        </table>
-        <h1>Leaderboard</h1>
-        <table class="lb">
-            <thead>
-                <tr>
-                    <th>#</th>
-                    <th>Driver</th>
-                    <th>Score</th>
-                    <th>Completion</th>
-                </tr>
-            </thead>
-            <tbody>
+                    </tbody>
+                </table>
+            </div>
+            <div class="stats-lb">
+                <h1>Leaderboard</h1>
+                <table class="lb">
+                    <thead>
+                        <tr>
+                            <th>#</th>
+                            <th>Driver</th>
+                            <th>Score</th>
+                            <th>Completion</th>
+                        </tr>
+                    </thead>
+                    <tbody>
 <?php
 $rank = 1;
 foreach($driversExtsDone as $drivername => $numExtsDone) {
 ?>
-                <tr>
-                    <th class="lbCol-rank"><?= $rank ?></th>
-                    <td class="lbCol-driver"><?= $drivername ?></td>
-                    <td class="lbCol-score"><?= $numExtsDone." / ".$numTotalExts ?></td>
-                    <td class="lbCol-score"><?php printf("%.1f%%", ($numExtsDone / $numTotalExts * 100)) ?></td>
-                </tr>
+                        <tr>
+                            <th class="lbCol-rank"><?= $rank ?></th>
+                            <td class="lbCol-driver"><?= $drivername ?></td>
+                            <td class="lbCol-score"><?= $numExtsDone." / ".$numTotalExts ?></td>
+                            <td class="lbCol-score"><?php printf("%.1f%%", ($numExtsDone / $numTotalExts * 100)) ?></td>
+                        </tr>
 <?php
     $rank++;
 }
 ?>
-            </tbody>
-        </table>
+                    </tbody>
+                </table>
+            </div>
+        </div>
 <?php
 // Write the OpenGL matrix.
 writeMatrix($glVersions, $xml, $hints, $leaderboard);


### PR DESCRIPTION
This packs general info on the top of the page. It also makes the
main data (i.e. the GL matrices) begin closer to the top.

Flexbox is supported by all the browsers (minus Safari which still
needs a prefix...): http://caniuse.com/#feat=flexbox

![flexbox](https://cloud.githubusercontent.com/assets/6382548/7244664/10cef168-e7ad-11e4-90ea-34b2550c9cda.png)

@Xenopathic Could you review please?