### PR TITLE
Add percentage of completion for each GL version

### DIFF
--- a/http/css/style.css
+++ b/http/css/style.css
@@ -55,6 +55,15 @@ p { max-width: 800px; }
     width: 100%;
 }
 
+.mesaScore {
+    font-size: 0.7em;
+    color: #DDDDDD;
+    cursor: help;
+}
+.mesaScore-done { color: #99D75F; }
+.mesaScore-almost { color: #E1A25E; }
+.mesaScore-notyet { color: #B94B3D; }
+
 .hCellVendor-default { background-color: #d3d7cf; }
 .hCellVendor-soft    { background-color: #d1b4ce; }
 .hCellVendor-intel   { background-color: #b9cee4; }

--- a/http/js/script.js
+++ b/http/js/script.js
@@ -90,10 +90,29 @@ $(document).ready(function() {
 //        }
 //    });
 
+    $(".mesaScore").tipsy({
+        fallback: "It represents the completion status of `mesa` only",
+        gravity: "n",
+        fade: true
+    });
+
     // adjust the opacity of the 'modified' text based on age
     var timeConst = 1.2e7;
     $('.task span').each(function() {
         var timeDiff = (Date.now()/1000) - $(this).data('timestamp');
         $(this).css('opacity', gaussian(timeDiff, 1, 0, timeConst));
+    });
+
+    $('.mesaScore').each(function() {
+        var blend = Math.round($(this).data('score'));
+        if (blend == 100) {
+            $(this).addClass('mesaScore-done');
+        }
+        else if (blend < 90) {
+            $(this).addClass('mesaScore-notyet');
+        }
+        else {
+            $(this).addClass('mesaScore-almost');
+        }
     });
 });


### PR DESCRIPTION
@Xenopathic I add a percentage right after the GL version title, it represents the overall score for the version. I separated in 3 subjective sections:
* if equal 0: done
* if greater than 75: almost there
* if less than 75: not there yet

I tried to blend colors from red to green, but the result wasn't convincing: we couldn't clearly distinguish the "not done" from the "almost done", and "the very almost done" to "the completely done".

![completion_colors](https://cloud.githubusercontent.com/assets/6382548/7625756/05f0c56c-f9ca-11e4-8679-4f171c67d2c8.png)
