### PR TITLE
Give #main "min-width:0" to prevent overflow on left side

### DIFF
--- a/http/css/style.css
+++ b/http/css/style.css
@@ -25,6 +25,8 @@ body {
     justify-content: center;
 }
 
+#main { min-width: 0; }
+
 p { max-width: 800px; }
 
 .stats {


### PR DESCRIPTION
See https://bugzilla.mozilla.org/show_bug.cgi?id=1173249 -- due to the "min-width:auto" feature of CSS flexbox, the #main area refuses to shrink below its intrinsic width. And due to "justify-content:center" on the body, it overflows equally on both sides, meaning some of its content gets pushed off the left side of the viewport.  And that content is not reachable via a scrollbar.

This happens in both Firefox (all recent versions) and Chrome 45 (dev channel). Likely happens in Microsoft's "Edge" browser as well.

The standard fix for this is to give the flex item "min-width:0" to allow it to shrink.  (Its own content will still overflow if the window is too small, but it'll overflow to the right instead of the left, and hence be scrollable.)