### PR TITLE
Implement RSS feed for latest commits

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,3 +82,14 @@ jQuery Tipsy is available under the MIT License.
 PSR Log is available under the MIT License.
 
 Symfony is available under the MIT License.
+
+### Media files
+
+The Mesamatrix banner image was created by Robin McCorkell, and is licensed
+under the Creative Commons Attribution-ShareAlike 4.0 International license.
+Go tweak it, and send us your improvements!
+
+The RSS feed icon is freely available from the Mozilla Foundation at
+http://www.feedicons.com/
+
+The GitHub 'Fork me' ribbon is available under the MIT license.

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,9 @@
         "psr/log": "1.0.0",
         "monolog/monolog": "~1.12",
         "symfony/monolog-bridge": "~2.6",
-        "symfony/event-dispatcher": "~2.6"
+        "symfony/event-dispatcher": "~2.6",
+        "suin/php-rss-writer": "~1.0",
+        "symfony/http-foundation": "~2.6"
     },
 
     "autoload": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "3977f759805266854dcac48fb3c600c7",
+    "hash": "ae71165f8df97b5830e36b4df37006ea",
     "packages": [
         {
             "name": "monolog/monolog",
@@ -115,6 +115,51 @@
                 "psr-3"
             ],
             "time": "2012-12-21 11:40:51"
+        },
+        {
+            "name": "suin/php-rss-writer",
+            "version": "1.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/suin/php-rss-writer.git",
+                "reference": "82812ff988bb470f746d24e153cdc138e8838ff3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/suin/php-rss-writer/zipball/82812ff988bb470f746d24e153cdc138e8838ff3",
+                "reference": "82812ff988bb470f746d24e153cdc138e8838ff3",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "Suin\\RSSWriter": "Source"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "suin",
+                    "email": "suinyeze@gmail.com",
+                    "homepage": "https://www.facebook.com/suinyeze",
+                    "role": "Developer, Renaming Specialist"
+                }
+            ],
+            "description": "Yet another simple RSS writer library for PHP 5.3 or later.",
+            "homepage": "https://github.com/suin/php-rss-writer",
+            "keywords": [
+                "feed",
+                "generator",
+                "rss",
+                "writer"
+            ],
+            "time": "2014-03-12 06:05:28"
         },
         {
             "name": "symfony/console",
@@ -230,6 +275,59 @@
             "description": "Symfony EventDispatcher Component",
             "homepage": "http://symfony.com",
             "time": "2015-02-01 16:10:57"
+        },
+        {
+            "name": "symfony/http-foundation",
+            "version": "v2.7.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/HttpFoundation.git",
+                "reference": "729de183da037c125c5f6366bd4f0631ba1a1abb"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/HttpFoundation/zipball/729de183da037c125c5f6366bd4f0631ba1a1abb",
+                "reference": "729de183da037c125c5f6366bd4f0631ba1a1abb",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.9"
+            },
+            "require-dev": {
+                "symfony/expression-language": "~2.4",
+                "symfony/phpunit-bridge": "~2.7"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.7-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\HttpFoundation\\": ""
+                },
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony HttpFoundation Component",
+            "homepage": "https://symfony.com",
+            "time": "2015-05-22 14:54:25"
         },
         {
             "name": "symfony/monolog-bridge",

--- a/http/css/style.css
+++ b/http/css/style.css
@@ -27,6 +27,22 @@ body {
 
 #main { min-width: 0; }
 
+header {
+    display: flex;
+    justify-content: space-between;
+}
+
+header .header-icons {
+    padding: 14px;
+    display: flex;
+    align-items: flex-end;
+}
+header .header-icons img {
+    width: 32px;
+    height: 32px;
+    margin: 3px;
+}
+
 p { max-width: 800px; }
 
 .stats {

--- a/http/images/banner.svg
+++ b/http/images/banner.svg
@@ -1,0 +1,617 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:osb="http://www.openswatchbook.org/uri/2009/osb"
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="663"
+   height="132"
+   id="svg2985"
+   version="1.1"
+   inkscape:version="0.48.4 r9939"
+   sodipodi:docname="banner.svg">
+  <defs
+     id="defs2987">
+    <marker
+       style="overflow:visible"
+       inkscape:stockid="InfiniteLineStart"
+       id="InfiniteLineStart"
+       refX="0"
+       refY="0"
+       orient="auto">
+      <g
+         id="g6078"
+         style="fill:#000000"
+         transform="translate(-13,0)">
+        <circle
+           d="M 3.8,0 C 3.8,0.44182781 3.4418278,0.80000001 3,0.80000001 2.5581722,0.80000001 2.2,0.44182781 2.2,0 c 0,-0.44182781 0.3581722,-0.80000001 0.8,-0.80000001 0.4418278,0 0.8,0.3581722 0.8,0.80000001 z"
+           id="circle6080"
+           r="0.80000001"
+           cy="0"
+           cx="3"
+           sodipodi:cx="3"
+           sodipodi:cy="0"
+           sodipodi:rx="0.80000001"
+           sodipodi:ry="0.80000001" />
+        <circle
+           d="M 7.3,0 C 7.3,0.44182781 6.9418278,0.80000001 6.5,0.80000001 6.0581722,0.80000001 5.7,0.44182781 5.7,0 c 0,-0.44182781 0.3581722,-0.80000001 0.8,-0.80000001 0.4418278,0 0.8,0.3581722 0.8,0.80000001 z"
+           id="circle6082"
+           r="0.80000001"
+           cy="0"
+           cx="6.5"
+           sodipodi:cx="6.5"
+           sodipodi:cy="0"
+           sodipodi:rx="0.80000001"
+           sodipodi:ry="0.80000001" />
+        <circle
+           d="M 10.8,0 C 10.8,0.44182781 10.441828,0.80000001 10,0.80000001 9.5581722,0.80000001 9.2,0.44182781 9.2,0 c 0,-0.44182781 0.3581722,-0.80000001 0.8,-0.80000001 0.441828,0 0.8,0.3581722 0.8,0.80000001 z"
+           id="circle6084"
+           r="0.80000001"
+           cy="0"
+           cx="10"
+           sodipodi:cx="10"
+           sodipodi:cy="0"
+           sodipodi:rx="0.80000001"
+           sodipodi:ry="0.80000001" />
+      </g>
+    </marker>
+    <linearGradient
+       id="linearGradient5792"
+       osb:paint="solid">
+      <stop
+         style="stop-color:#676767;stop-opacity:1;"
+         offset="0"
+         id="stop5794" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4343"
+       osb:paint="gradient">
+      <stop
+         style="stop-color:#676767;stop-opacity:0.79411763;"
+         offset="0"
+         id="stop4345" />
+      <stop
+         style="stop-color:#676767;stop-opacity:0.74264705;"
+         offset="1"
+         id="stop4347" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3950"
+       osb:paint="gradient">
+      <stop
+         id="stop3952"
+         offset="0"
+         style="stop-color:#2ca0d6;stop-opacity:0.66911763;" />
+      <stop
+         style="stop-color:#376dc8;stop-opacity:0.5;"
+         offset="0.51190478"
+         id="stop4004" />
+      <stop
+         id="stop4006"
+         offset="1"
+         style="stop-color:#2a2bdb;stop-opacity:0.25;" />
+    </linearGradient>
+    <filter
+       inkscape:collect="always"
+       id="filter4024"
+       x="-0.049526662"
+       width="1.0990533"
+       y="-0.16502927"
+       height="1.3300585"
+       color-interpolation-filters="sRGB">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="9.5235639"
+         id="feGaussianBlur4026" />
+    </filter>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4343"
+       id="linearGradient5816"
+       x1="301.65268"
+       y1="6.3835649"
+       x2="768.60065"
+       y2="6.3835649"
+       gradientUnits="userSpaceOnUse" />
+    <filter
+       inkscape:collect="always"
+       id="filter5826"
+       color-interpolation-filters="sRGB">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.14662782"
+         id="feGaussianBlur5828" />
+    </filter>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4343"
+       id="linearGradient3906"
+       gradientUnits="userSpaceOnUse"
+       x1="301.65268"
+       y1="6.3835649"
+       x2="768.60065"
+       y2="6.3835649" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4343"
+       id="linearGradient3908"
+       gradientUnits="userSpaceOnUse"
+       x1="301.65268"
+       y1="6.3835649"
+       x2="768.60065"
+       y2="6.3835649" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4343"
+       id="linearGradient3910"
+       gradientUnits="userSpaceOnUse"
+       x1="301.65268"
+       y1="6.3835649"
+       x2="768.60065"
+       y2="6.3835649" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4343"
+       id="linearGradient3912"
+       gradientUnits="userSpaceOnUse"
+       x1="301.65268"
+       y1="6.3835649"
+       x2="768.60065"
+       y2="6.3835649" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4343"
+       id="linearGradient3914"
+       gradientUnits="userSpaceOnUse"
+       x1="301.65268"
+       y1="6.3835649"
+       x2="768.60065"
+       y2="6.3835649" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4343"
+       id="linearGradient3916"
+       gradientUnits="userSpaceOnUse"
+       x1="301.65268"
+       y1="6.3835649"
+       x2="768.60065"
+       y2="6.3835649" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4343"
+       id="linearGradient3918"
+       gradientUnits="userSpaceOnUse"
+       x1="301.65268"
+       y1="6.3835649"
+       x2="768.60065"
+       y2="6.3835649" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4343"
+       id="linearGradient3920"
+       gradientUnits="userSpaceOnUse"
+       x1="301.65268"
+       y1="6.3835649"
+       x2="768.60065"
+       y2="6.3835649" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4343"
+       id="linearGradient3922"
+       gradientUnits="userSpaceOnUse"
+       x1="301.65268"
+       y1="6.3835649"
+       x2="768.60065"
+       y2="6.3835649" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4343"
+       id="linearGradient3924"
+       gradientUnits="userSpaceOnUse"
+       x1="301.65268"
+       y1="6.3835649"
+       x2="768.60065"
+       y2="6.3835649" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4343"
+       id="linearGradient3926"
+       gradientUnits="userSpaceOnUse"
+       x1="301.65268"
+       y1="6.3835649"
+       x2="768.60065"
+       y2="6.3835649" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4343"
+       id="linearGradient3928"
+       gradientUnits="userSpaceOnUse"
+       x1="301.65268"
+       y1="6.3835649"
+       x2="768.60065"
+       y2="6.3835649" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4343"
+       id="linearGradient3930"
+       gradientUnits="userSpaceOnUse"
+       x1="301.65268"
+       y1="6.3835649"
+       x2="768.60065"
+       y2="6.3835649" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4343"
+       id="linearGradient3932"
+       gradientUnits="userSpaceOnUse"
+       x1="301.65268"
+       y1="6.3835649"
+       x2="768.60065"
+       y2="6.3835649" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4343"
+       id="linearGradient3934"
+       gradientUnits="userSpaceOnUse"
+       x1="301.65268"
+       y1="6.3835649"
+       x2="768.60065"
+       y2="6.3835649" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4343"
+       id="linearGradient3936"
+       gradientUnits="userSpaceOnUse"
+       x1="301.65268"
+       y1="6.3835649"
+       x2="768.60065"
+       y2="6.3835649" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4343"
+       id="linearGradient3938"
+       gradientUnits="userSpaceOnUse"
+       x1="301.65268"
+       y1="6.3835649"
+       x2="768.60065"
+       y2="6.3835649" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4343"
+       id="linearGradient3940"
+       gradientUnits="userSpaceOnUse"
+       x1="301.65268"
+       y1="6.3835649"
+       x2="768.60065"
+       y2="6.3835649" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4343"
+       id="linearGradient3942"
+       gradientUnits="userSpaceOnUse"
+       x1="301.65268"
+       y1="6.3835649"
+       x2="768.60065"
+       y2="6.3835649" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4343"
+       id="linearGradient3944"
+       gradientUnits="userSpaceOnUse"
+       x1="301.65268"
+       y1="6.3835649"
+       x2="768.60065"
+       y2="6.3835649" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4343"
+       id="linearGradient3946"
+       gradientUnits="userSpaceOnUse"
+       x1="301.65268"
+       y1="6.3835649"
+       x2="768.60065"
+       y2="6.3835649" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4343"
+       id="linearGradient3948"
+       gradientUnits="userSpaceOnUse"
+       x1="301.65268"
+       y1="6.3835649"
+       x2="768.60065"
+       y2="6.3835649" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4343"
+       id="linearGradient3951"
+       gradientUnits="userSpaceOnUse"
+       x1="301.65268"
+       y1="6.3835649"
+       x2="768.60065"
+       y2="6.3835649" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4343"
+       id="linearGradient3953"
+       gradientUnits="userSpaceOnUse"
+       x1="301.65268"
+       y1="6.3835649"
+       x2="768.60065"
+       y2="6.3835649" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4343"
+       id="linearGradient3955"
+       gradientUnits="userSpaceOnUse"
+       x1="301.65268"
+       y1="6.3835649"
+       x2="768.60065"
+       y2="6.3835649" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4343"
+       id="linearGradient3957"
+       gradientUnits="userSpaceOnUse"
+       x1="301.65268"
+       y1="6.3835649"
+       x2="768.60065"
+       y2="6.3835649" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3950"
+       id="linearGradient3959"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(8,4.5)"
+       spreadMethod="pad"
+       x1="335.43372"
+       y1="4.25"
+       x2="808.56628"
+       y2="0.75" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="2"
+     inkscape:cx="418.83554"
+     inkscape:cy="73.22168"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     inkscape:window-width="1916"
+     inkscape:window-height="1033"
+     inkscape:window-x="0"
+     inkscape:window-y="45"
+     inkscape:window-maximized="0" />
+  <metadata
+     id="metadata2990">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="layer1"
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,42)">
+    <g
+       style="font-size:40px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:Sans"
+       id="text3094"
+       transform="translate(-0.5,13.5)">
+      <path
+         d="m 89.820312,-26.808594 c -1.132902,7.2e-5 -2.3829,0.175853 -3.75,0.527344 -1.367273,0.351633 -2.75399,0.859445 -4.160156,1.523438 l 0.585938,63.164062 c -8.4e-5,0.468756 0.703041,1.054693 2.109375,1.757812 1.445225,0.664067 3.574129,1.269535 6.386718,1.816407 l 0,2.519531 -26.542968,0 0,-2.519531 c 2.656182,-0.546872 4.824148,-1.132809 6.503906,-1.757813 1.718676,-0.664057 2.57805,-1.269525 2.578125,-1.816406 l -0.527344,-55.253906 c -0.03914,0.117248 -0.09773,0.253967 -0.175781,0.410156 L 47.222656,44.5 l -2.871094,0 -26.25,-60.878906 -0.527343,54.785156 c -1.9e-5,0.468756 0.703105,1.054693 2.109375,1.757812 1.44529,0.664067 3.574194,1.269535 6.386718,1.816407 l 0,2.519531 -23.554687,0 0,-2.519531 C 5.2109313,41.433597 7.3007729,40.84766 8.7851563,40.222656 10.26952,39.558599 11.011707,38.953131 11.011719,38.40625 l 0.585937,-62.871094 C 10.11327,-25.363211 8.6093654,-25.96868 7.0859375,-26.28125 5.6015559,-26.632741 4.2734322,-26.808522 3.1015625,-26.808594 l 0,-2.519531 16.7578125,0 c 0.390604,7.4e-5 0.703103,0.05867 0.9375,0.175781 0.273415,0.117261 0.527321,0.351636 0.761719,0.703125 0.273414,0.351635 0.566383,0.859447 0.878906,1.523438 0.312476,0.625071 0.703101,1.464913 1.171875,2.519531 L 46.929687,28.445312 69.3125,-24.40625 c 0.507742,-1.171805 0.917898,-2.070242 1.230469,-2.695312 0.312428,-0.663991 0.585865,-1.152271 0.820312,-1.464844 0.273365,-0.351489 0.527271,-0.566333 0.761719,-0.644531 0.273364,-0.07805 0.585864,-0.117114 0.9375,-0.117188 l 16.757812,0 0,2.519531 0,0"
+         style="font-size:120px;font-variant:normal;font-stretch:normal;font-family:Gentium;-inkscape-font-specification:Gentium"
+         id="path3856"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 124.85938,-5.65625 c -1.99222,5.02e-5 -3.82816,0.3906748 -5.50782,1.171875 -1.67971,0.7812982 -3.18361,1.8750471 -4.51172,3.28125 -1.28908,1.4062943 -2.38283,3.1055113 -3.28125,5.0976563 -0.85939,1.9922261 -1.48439,4.1992551 -1.875,6.6210937 l 25.01953,0 c 0.8984,3.4e-5 1.48434,-0.136685 1.75782,-0.410156 0.31246,-0.3124655 0.46871,-0.8788712 0.46875,-1.699219 -4e-5,-0.7030882 -0.0586,-1.5429311 -0.17578,-2.5195313 -0.11723,-0.9765229 -0.35161,-1.9726156 -0.70313,-2.9882812 -0.31254,-1.0546448 -0.76176,-2.08980006 -1.34766,-3.10546875 -0.54691,-1.01557925 -1.26956,-1.91401585 -2.16796,-2.69531255 -0.89848,-0.8202642 -1.99223,-1.4843261 -3.28125,-1.9921874 -1.25004,-0.5077626 -2.71488,-0.7616686 -4.39453,-0.7617188 m 21.67968,17.519531 c -0.70317,0.781282 -1.64067,1.503938 -2.8125,2.167969 -1.17192,0.664092 -2.38286,1.250029 -3.63281,1.757813 l -30.82031,0 0,0.175781 c -2e-5,2.929713 0.39061,5.761741 1.17187,8.496093 0.8203,2.69533 1.97264,5.097672 3.45703,7.207032 1.48436,2.070323 3.30076,3.730478 5.44922,4.980468 2.14841,1.250007 4.57029,1.875006 7.26563,1.875 1.2109,6e-6 2.38278,-0.05859 3.51562,-0.175781 1.17184,-0.156243 2.42184,-0.488274 3.75,-0.996094 1.32809,-0.546867 2.79293,-1.347647 4.39453,-2.402343 1.64058,-1.054677 3.55465,-2.480457 5.74219,-4.277344 0.50777,0.273451 0.93745,0.664076 1.28906,1.171875 0.39058,0.507825 0.68355,0.91798 0.87891,1.230469 -2.61724,2.851571 -4.92192,5.156256 -6.91406,6.914062 -1.95317,1.718753 -3.80864,3.046877 -5.56641,3.984375 -1.71878,0.9375 -3.43753,1.542968 -5.15625,1.816406 -1.67972,0.312499 -3.51565,0.468749 -5.50781,0.46875 -3.00784,-1e-6 -5.87893,-0.644532 -8.61328,-1.933593 -2.69533,-1.289061 -5.07814,-3.105466 -7.14844,-5.449219 -2.07032,-2.382804 -3.73048,-5.234364 -4.98047,-8.554688 -1.21094,-3.359357 -1.81641,-7.109353 -1.8164,-11.25 -1e-5,-2.617159 0.29296,-5.195281 0.8789,-7.734374 0.58593,-2.5390273 1.42578,-4.9413686 2.51953,-7.2070318 1.13281,-2.2655823 2.49999,-4.35542397 4.10157,-6.2695312 1.60154,-1.9140139 3.41795,-3.5741685 5.44921,-4.9804687 0.85936,-0.5858853 1.81639,-1.152291 2.8711,-1.6992188 1.09373,-0.5858836 2.22654,-1.0936956 3.39844,-1.5234375 1.17184,-0.429632 2.32419,-0.761663 3.45703,-0.996094 1.17184,-0.273381 2.28512,-0.4101 3.33984,-0.410156 2.57809,5.6e-5 4.84371,0.351618 6.79687,1.054687 1.99215,0.70318 3.73043,1.6602103 5.21485,2.8710943 1.48433,1.1719261 2.73433,2.5586435 3.75,4.1601562 1.01558,1.5625466 1.83589,3.22270119 2.46094,4.9804687 0.66401,1.757854 1.13276,3.5547272 1.40625,5.390625 0.27338,1.796911 0.4101,3.5156598 0.41015,5.1562498"
+         style="font-size:120px;font-variant:normal;font-stretch:normal;font-family:Gentium;-inkscape-font-specification:Gentium"
+         id="path3858"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 192.35937,27.917969 c -4e-5,2.773451 -0.39066,5.156261 -1.17187,7.148437 -0.78129,1.953133 -1.79691,3.613287 -3.04688,4.980469 -1.25003,1.367191 -2.63675,2.460939 -4.16015,3.28125 -1.52347,0.820313 -3.02737,1.445312 -4.51172,1.875 -1.4844,0.429686 -2.89065,0.703124 -4.21875,0.820312 -1.28909,0.156249 -2.30471,0.234374 -3.04688,0.234375 -1.87501,-1e-6 -4.14064,-0.351563 -6.79687,-1.054687 -2.6172,-0.703125 -5.23438,-1.777343 -7.85156,-3.222656 -0.27345,-0.117185 -0.46876,-0.742184 -0.58594,-1.875 -0.0781,-1.17187 -0.0977,-2.499993 -0.0586,-3.984375 0.0781,-1.523428 0.1953,-3.046864 0.35156,-4.570313 0.19531,-1.523423 0.42968,-2.734359 0.70312,-3.632812 l 2.51953,0.644531 c 0.0781,1.640639 0.50781,3.183607 1.28907,4.628906 0.78124,1.445323 1.81639,2.714853 3.10547,3.808594 1.32811,1.093756 2.85154,1.953131 4.57031,2.578125 1.75779,0.625004 3.65232,0.937504 5.68359,0.9375 1.40623,4e-6 2.69529,-0.21484 3.86719,-0.644531 1.17185,-0.468745 2.18747,-1.113276 3.04687,-1.933594 0.85935,-0.820305 1.52341,-1.796867 1.99219,-2.929688 0.46872,-1.171864 0.70309,-2.441394 0.70313,-3.808593 -4e-5,-1.562485 -0.42972,-2.949203 -1.28907,-4.160157 -0.82034,-1.210918 -1.91409,-2.304667 -3.28125,-3.28125 -1.36721,-1.015603 -2.92971,-1.953102 -4.6875,-2.8125 -1.71877,-0.898413 -3.47658,-1.81638 -5.27343,-2.753906 -1.64064,-0.820285 -3.22267,-1.69919 -4.7461,-2.636718 -1.52345,-0.937471 -2.89063,-1.992157 -4.10156,-3.164063 -1.17188,-1.171842 -2.12891,-2.4804342 -2.87109,-3.9257812 -0.70313,-1.4452751 -1.0547,-3.1054297 -1.05469,-4.9804688 -1e-5,-2.4218316 0.48827,-4.5702669 1.46484,-6.4453125 0.97656,-1.9140131 2.26562,-3.515574 3.86719,-4.8046875 1.64061,-1.2890089 3.49608,-2.26557 5.56641,-2.929688 2.10935,-0.703069 4.27732,-1.054631 6.5039,-1.054687 1.21092,5.6e-5 2.53904,0.117244 3.98438,0.351562 1.48434,0.195369 2.92966,0.488337 4.33594,0.878907 1.44528,0.390679 2.79293,0.8594289 4.04296,1.4062497 1.24997,0.5469281 2.26559,1.1719275 3.04688,1.8750001 0.23434,0.2344265 0.25387,0.7617697 0.0586,1.5820312 -0.15629,0.8203618 -0.42972,1.7187984 -0.82031,2.6953125 -0.3516,0.976609 -0.74222,1.8945768 -1.17187,2.75390625 -0.42973,0.85941885 -0.76176,1.44535575 -0.9961,1.75781245 l -2.28515,-0.46875 c -1.87504,-2.8124537 -3.82816,-4.7655768 -5.85938,-5.8593749 -1.99221,-1.1327621 -3.94534,-1.6991678 -5.85937,-1.6992188 -1.28909,5.1e-5 -2.44143,0.2148945 -3.45704,0.6445313 -1.01564,0.4297374 -1.89454,0.996143 -2.63671,1.6992187 -0.70314,0.6641105 -1.25002,1.4062972 -1.64063,2.2265625 -0.35158,0.8203581 -0.52736,1.64066977 -0.52734,2.4609375 -2e-5,1.2500427 0.37108,2.3828541 1.11328,3.3984375 0.74217,0.9766021 1.71873,1.9141011 2.92969,2.8125 1.21091,0.8594119 2.5781,1.6992548 4.10156,2.5195313 1.56248,0.7812847 3.16404,1.6015957 4.80469,2.4609377 1.67966,0.859407 3.37887,1.777374 5.09765,2.753906 1.71872,0.976592 3.26169,2.109403 4.62891,3.398437 1.36715,1.250026 2.48043,2.695337 3.33984,4.335938 0.85934,1.601583 1.28902,3.496113 1.28906,5.683594"
+         style="font-size:120px;font-variant:normal;font-stretch:normal;font-family:Gentium;-inkscape-font-specification:Gentium"
+         id="path3860"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 218.375,38.640625 c 2.34373,6e-6 4.82419,-0.585931 7.44141,-1.757813 2.65622,-1.210928 5.46871,-3.105458 8.4375,-5.683593 l 0,-15.292969 -6.97266,1.347656 c -2.65628,0.468777 -4.96096,1.15237 -6.91406,2.050781 -1.91409,0.898462 -3.49612,1.953149 -4.7461,3.164063 -1.25001,1.210958 -2.16798,2.558613 -2.7539,4.042969 -0.58595,1.445329 -0.87892,2.968765 -0.87891,4.570312 -1e-5,1.562512 0.23436,2.832042 0.70313,3.808594 0.46873,0.976571 1.03514,1.75782 1.69921,2.34375 0.70311,0.546882 1.40624,0.917975 2.10938,1.113281 0.74217,0.195319 1.36717,0.292975 1.875,0.292969 m 33.63281,1.054687 c -3.32036,2.30469 -6.07426,3.964845 -8.26172,4.980469 -2.14848,1.054687 -3.76957,1.58203 -4.86328,1.582031 -1.2891,-1e-6 -2.36332,-0.898438 -3.22265,-2.695312 -0.85942,-1.796872 -1.32817,-4.277339 -1.40625,-7.441406 -1.75785,1.757819 -3.51566,3.281255 -5.27344,4.570312 -1.75784,1.289065 -3.47659,2.343752 -5.15625,3.164063 -1.67971,0.820312 -3.28127,1.42578 -4.80469,1.816406 -1.48439,0.390623 -2.85158,0.585936 -4.10156,0.585937 -1.40627,-1e-6 -2.85158,-0.234376 -4.33594,-0.703125 -1.48439,-0.46875 -2.83204,-1.210937 -4.04297,-2.226562 -1.17188,-1.015623 -2.14844,-2.324215 -2.92969,-3.925781 -0.78125,-1.601556 -1.17187,-3.535148 -1.17187,-5.800782 0,-2.304674 0.41015,-4.492172 1.23047,-6.5625 0.85937,-2.109355 2.10937,-4.023416 3.75,-5.742187 1.67967,-1.718725 3.74999,-3.203099 6.21094,-4.453125 2.46092,-1.289034 5.33201,-2.265595 8.61328,-2.929687 l 12.01172,-2.402344 0,-8.1445315 c -4e-5,-1.3280825 -0.15629,-2.55855006 -0.46875,-3.69140625 -0.31254,-1.17182905 -0.83988,-2.16792175 -1.58204,-2.98828125 -0.74222,-0.8593263 -1.75784,-1.5038569 -3.04687,-1.9335937 -1.25003,-0.4686998 -2.83206,-0.6835434 -4.74609,-0.6445313 -1.25003,0.039113 -2.4805,0.2539564 -3.69141,0.6445313 -1.21096,0.3906743 -2.26565,0.9375488 -3.16406,1.6406249 -0.89846,0.7031725 -1.60158,1.5430154 -2.10938,2.5195313 -0.50783,0.93754465 -0.70314,1.99223109 -0.58594,3.1640625 0.039,0.3516046 -0.37111,0.7617604 -1.23046,1.2304688 -0.82033,0.4297282 -1.81642,0.8203528 -2.98829,1.1718749 -1.13282,0.3516022 -2.26563,0.6250394 -3.39843,0.8203125 -1.09376,0.1953516 -1.87501,0.234414 -2.34375,0.1171875 l -0.82032,-2.2851562 c 0.89844,-1.9530817 2.26562,-3.8280798 4.10157,-5.625 1.83592,-1.7968262 3.92576,-3.3788559 6.26953,-4.7460937 2.38279,-1.3671344 4.88279,-2.4608834 7.5,-3.2812498 2.65622,-0.820257 5.21481,-1.230413 7.67578,-1.230469 4.29684,5.6e-5 7.59762,1.132868 9.90234,3.3984375 2.34371,2.2266131 3.51558,5.35161 3.51563,9.375 l 0,33.0468745 c -5e-5,1.640634 0.2148,2.812508 0.64453,3.515625 0.42964,0.703132 0.99605,1.054694 1.69922,1.054688 0.54683,6e-6 1.24995,-0.09765 2.10937,-0.292969 0.85933,-0.195306 2.07026,-0.624993 3.63282,-1.289062 l 0.8789,2.636718 0,0"
+         style="font-size:120px;font-variant:normal;font-stretch:normal;font-family:Gentium;-inkscape-font-specification:Gentium"
+         id="path3862"
+         inkscape:connector-curvature="0" />
+    </g>
+    <g
+       id="g3877"
+       transform="matrix(0.86202292,0,0,0.88529196,37.582483,10.749298)">
+      <g
+         transform="matrix(0.96450913,0,0,0.96737542,-39.843806,4.850715)"
+         style="opacity:0.81224491;fill:none;stroke:url(#linearGradient3957);stroke-width:1;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:1, 3;stroke-dashoffset:0;filter:url(#filter5826)"
+         id="g4222">
+        <path
+           style="fill:none;stroke:url(#linearGradient3906);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:0.67605633;stroke-dasharray:1, 3;stroke-dashoffset:0"
+           d="M 337,38.5 364,156"
+           id="path4028"
+           inkscape:connector-curvature="0"
+           transform="translate(0,-90)" />
+        <path
+           style="fill:none;stroke:url(#linearGradient3908);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:0.67605633;stroke-dasharray:1, 3;stroke-dashoffset:0"
+           d="m 363,-51.25 27,117.5"
+           id="path4028-4"
+           inkscape:connector-curvature="0" />
+        <path
+           style="fill:none;stroke:url(#linearGradient3910);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:0.67605633;stroke-dasharray:1, 3;stroke-dashoffset:0"
+           d="m 389,-51.25 27,117.5"
+           id="path4028-0"
+           inkscape:connector-curvature="0" />
+        <path
+           style="fill:none;stroke:url(#linearGradient3912);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:0.67605633;stroke-dasharray:1, 3;stroke-dashoffset:0"
+           d="m 415,-52.25 27,117.5"
+           id="path4028-8"
+           inkscape:connector-curvature="0" />
+        <path
+           style="fill:none;stroke:url(#linearGradient3914);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:0.67605633;stroke-dasharray:1, 3;stroke-dashoffset:0"
+           d="m 440.5,-52.75 27,117.5"
+           id="path4028-7"
+           inkscape:connector-curvature="0" />
+        <path
+           style="fill:none;stroke:url(#linearGradient3916);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:0.67605633;stroke-dasharray:1, 3;stroke-dashoffset:0"
+           d="m 466.5,-53.25 27,117.5"
+           id="path4028-80"
+           inkscape:connector-curvature="0" />
+        <path
+           style="fill:none;stroke:url(#linearGradient3918);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:0.67605633;stroke-dasharray:1, 3;stroke-dashoffset:0"
+           d="m 492,-53.25 27,117.5"
+           id="path4028-1"
+           inkscape:connector-curvature="0" />
+        <path
+           style="fill:none;stroke:url(#linearGradient3920);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:0.67605633;stroke-dasharray:1, 3;stroke-dashoffset:0"
+           d="m 517,-52.75 27,117.5"
+           id="path4028-5"
+           inkscape:connector-curvature="0" />
+        <path
+           style="fill:none;stroke:url(#linearGradient3922);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:0.67605633;stroke-dasharray:1, 3;stroke-dashoffset:0"
+           d="m 543,-53.25 27,117.5"
+           id="path4028-9"
+           inkscape:connector-curvature="0" />
+        <path
+           style="fill:none;stroke:url(#linearGradient3924);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:0.67605633;stroke-dasharray:1, 3;stroke-dashoffset:0"
+           d="m 569,-53.25 27,117.5"
+           id="path4028-12"
+           inkscape:connector-curvature="0" />
+        <path
+           style="fill:none;stroke:url(#linearGradient3926);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:0.67605633;stroke-dasharray:1, 3;stroke-dashoffset:0"
+           d="m 594,-53.75 27,117.5"
+           id="path4028-57"
+           inkscape:connector-curvature="0" />
+        <path
+           style="fill:none;stroke:url(#linearGradient3928);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:0.67605633;stroke-dasharray:1, 3;stroke-dashoffset:0"
+           d="m 620,-53.25 27,117.5"
+           id="path4028-2"
+           inkscape:connector-curvature="0" />
+        <path
+           style="fill:none;stroke:url(#linearGradient3930);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:0.67605633;stroke-dasharray:1, 3;stroke-dashoffset:0"
+           d="m 645,-53.75 27,117.5"
+           id="path4028-6"
+           inkscape:connector-curvature="0" />
+        <path
+           style="fill:none;stroke:url(#linearGradient3932);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:0.67605633;stroke-dasharray:1, 3;stroke-dashoffset:0"
+           d="m 670.5,-53.25 27,117.5"
+           id="path4028-56"
+           inkscape:connector-curvature="0" />
+        <path
+           style="fill:none;stroke:url(#linearGradient3934);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:0.67605633;stroke-dasharray:1, 3;stroke-dashoffset:0"
+           d="m 696,-53.75 27,117.5"
+           id="path4028-76"
+           inkscape:connector-curvature="0" />
+        <path
+           style="fill:none;stroke:url(#linearGradient3936);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:0.67605633;stroke-dasharray:1, 3;stroke-dashoffset:0"
+           d="m 721,-52.75 27,117.5"
+           id="path4028-70"
+           inkscape:connector-curvature="0" />
+        <path
+           style="fill:none;stroke:url(#linearGradient3938);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:0.67605633;stroke-dasharray:1, 3;stroke-dashoffset:0"
+           d="m 746.38911,-52.860889 20.72178,92.721778"
+           id="path4028-43"
+           inkscape:connector-curvature="0" />
+        <path
+           style="fill:none;stroke:url(#linearGradient3940);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:0.67605633;stroke-dasharray:1, 3;stroke-dashoffset:0"
+           d="m 312.5,-51.25 27,117.5"
+           id="path4028-3"
+           inkscape:connector-curvature="0" />
+        <path
+           style="fill:none;stroke:url(#linearGradient3942);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:0.67605633;stroke-dasharray:1, 3;stroke-dashoffset:0"
+           d="m 303.73287,17.48287 14.03426,49.03426"
+           id="path4028-52"
+           inkscape:connector-curvature="0" />
+        <path
+           style="fill:none;stroke:url(#linearGradient3944);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:1, 3;stroke-dashoffset:0"
+           d="m 302.00458,-38.004575 461.99084,-0.99085"
+           id="path4174"
+           inkscape:connector-curvature="0" />
+        <path
+           style="fill:none;stroke:url(#linearGradient3946);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:1, 3;stroke-dashoffset:0"
+           d="m 307.25312,-17.503123 457.99376,-0.993754"
+           id="path4174-5"
+           inkscape:connector-curvature="0" />
+        <path
+           style="fill:none;stroke:url(#linearGradient3948);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:1, 3;stroke-dashoffset:0"
+           d="M 306.75349,1.9965128 765.74651,1.0034872"
+           id="path4174-0"
+           inkscape:connector-curvature="0" />
+        <path
+           style="fill:none;stroke:url(#linearGradient3951);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:1, 3;stroke-dashoffset:0"
+           d="M 308.25294,20.997059 765.74706,20.002941"
+           id="path4174-3"
+           inkscape:connector-curvature="0" />
+        <path
+           style="fill:none;stroke:url(#linearGradient3953);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:1, 3;stroke-dashoffset:0"
+           d="M 307.75403,41.995968 768.24597,41.004032"
+           id="path4174-6"
+           inkscape:connector-curvature="0" />
+        <path
+           style="fill:none;stroke:url(#linearGradient3955);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:1, 3;stroke-dashoffset:0"
+           d="M 315.25129,61.498708 768.24871,60.501292"
+           id="path4174-4"
+           inkscape:connector-curvature="0" />
+      </g>
+      <rect
+         transform="matrix(0.96450913,0,0,0.80451569,-41.29057,10.221777)"
+         y="-63"
+         x="310.5"
+         height="138.5"
+         width="461.5"
+         id="rect3106"
+         style="fill:url(#linearGradient3959);fill-opacity:1;filter:url(#filter4024)" />
+    </g>
+    <g
+       style="font-size:40px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:Sans"
+       id="text3098"
+       transform="translate(-0.5,13.5)">
+      <path
+         d="m 277.94,-3.54 0,6.24 c 1.99998,-2.87995332 3.95998,-4.9199513 5.88,-6.12 1.91998,-1.1999489 4.15998,-1.7999483 6.72,-1.8 5.11997,5.17e-5 8.99996,2.8400489 11.64,8.52 4.39996,-5.6799511 8.91995,-8.5199483 13.56,-8.52 3.43995,5.17e-5 6.39994,1.2800504 8.88,3.84 2.47994,2.5600453 3.71994,5.6000423 3.72,9.12 l 0,33.84 4.08,0 c 2.15993,5e-6 3.23993,0.800004 3.24,2.4 -7e-5,1.680001 -1.08007,2.52 -3.24,2.52 l -8.88,0 0,-38.28 c -6e-5,-2.2399595 -0.80006,-4.1999575 -2.4,-5.88 -1.60006,-1.75995408 -3.44005,-2.6399532 -5.52,-2.64 -4.00005,4.68e-5 -8.16004,3.2800435 -12.48,9.84 l 0,32.04 4.08,0 c 2.15996,5e-6 3.23995,0.800004 3.24,2.4 -5e-5,1.680001 -1.08004,2.52 -3.24,2.52 l -8.88,0 0,-37.92 c -3e-5,-2.3199598 -0.80003,-4.3599577 -2.4,-6.12 -1.52003,-1.83995412 -3.32003,-2.7599532 -5.4,-2.76 -4.00002,4.68e-5 -8.20002,3.2800435 -12.6,9.84 l 0,32.04 4.08,0 c 2.15998,5e-6 3.23998,0.800004 3.24,2.4 -2e-5,1.680001 -1.08002,2.52 -3.24,2.52 l -13.08,0 c -2.08,0 -3.12,-0.839999 -3.12,-2.52 0,-1.599996 1.08,-2.399995 3.24,-2.4 l 4.08,0 0,-40.2 -4.08,0 c -2.16,4.51e-5 -3.24,-0.83995404 -3.24,-2.52 0,-1.5999508 1.08,-2.39995 3.24,-2.4 l 8.88,0"
+         style="font-size:120px;font-variant:normal;font-stretch:normal;font-family:FreeMono;-inkscape-font-specification:FreeMono"
+         id="path3865"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 346.95312,0.14 c -1e-5,-1.7599529 2.71999,-3.2399514 8.16001,-4.44 5.43997,-1.2799489 9.67996,-1.9199483 12.71999,-1.92 5.59996,5.17e-5 10.19996,1.4000503 13.8,4.2 3.67995,2.8000447 5.51995,6.3200412 5.52,10.56 l 0,32.04 6.48,0 c 2.15994,5e-6 3.23994,0.800004 3.24001,2.4 -7e-5,1.680001 -1.08007,2.52 -3.24001,2.52 l -11.4,0 0,-8.04 c -7.12004,6.640001 -14.76003,9.959998 -22.91999,9.96 -5.60003,-2e-6 -10.12002,-1.400001 -13.56001,-4.2 -3.44001,-2.879995 -5.16,-6.599991 -5.16,-11.16 0,-5.199981 2.31999,-9.399977 6.96001,-12.6 4.71997,-3.279971 10.83997,-4.919969 18.35999,-4.92 4.71997,3.1e-5 10.15996,0.84003 16.32,2.52 l 0,-8.52 c -5e-5,-2.9599601 -1.36004,-5.3199577 -4.08,-7.08 -2.72004,-1.83995412 -6.28003,-2.7599532 -10.68,-2.76 -3.68003,4.68e-5 -7.48002,0.64004616 -11.4,1.92 -3.92002,1.2800436 -6.20001,1.920043 -6.84,1.92 -0.64001,4.3e-5 -1.20001,-0.2399568 -1.67999,-0.72 -0.40002,-0.4799558 -0.60002,-1.0399553 -0.60001,-1.68 m 35.28,31.92 0,-10.8 c -4.80004,-1.199975 -9.92004,-1.799974 -15.35999,-1.8 -6.32003,2.6e-5 -11.48003,1.200025 -15.48001,3.6 -3.92001,2.32002 -5.88001,5.360017 -5.88,9.12 -1e-5,3.12001 1.23999,5.640008 3.72,7.56 2.47999,1.840004 5.79998,2.760003 9.96,2.76 4.23997,3e-6 8.11997,-0.799996 11.64,-2.4 3.59996,-1.599993 7.39996,-4.27999 11.4,-8.04"
+         style="font-size:120px;font-variant:normal;font-stretch:normal;font-family:FreeMono;-inkscape-font-specification:FreeMono"
+         id="path3867"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 415.22625,-4.54 26.4,0 c 2.15995,5e-5 3.23995,0.8000492 3.24,2.4 -5e-5,1.68004596 -1.08005,2.5200451 -3.24,2.52 l -26.4,0 0,32.04 c -2e-5,3.04001 1.19998,5.480008 3.6,7.32 2.39997,1.840004 5.67997,2.760003 9.84,2.76 3.35996,3e-6 6.91996,-0.439997 10.68,-1.32 3.83995,-0.959995 6.91995,-2.119994 9.24,-3.48 0.79994,-0.479992 1.43994,-0.719991 1.92,-0.72 0.55994,9e-6 1.07994,0.240008 1.56,0.72 0.47994,0.480007 0.71994,1.040007 0.72,1.68 -6e-5,1.760004 -2.72006,3.560003 -8.16,5.4 -5.36005,1.759999 -10.60004,2.639998 -15.72,2.64 -5.68003,-2e-6 -10.20003,-1.320001 -13.56,-3.96 -3.36002,-2.719995 -5.04002,-6.319992 -5.04,-10.8 l 0,-32.28 -8.88,0 c -2.24001,4.51e-5 -3.36001,-0.83995404 -3.36,-2.52 -1e-5,-1.5999508 1.11999,-2.39995 3.36,-2.4 l 8.88,0 0,-14.28 c -2e-5,-2.159934 0.83998,-3.239932 2.52,-3.24 1.59998,6.8e-5 2.39998,1.080066 2.4,3.24 l 0,14.28"
+         style="font-size:120px;font-variant:normal;font-stretch:normal;font-family:FreeMono;-inkscape-font-specification:FreeMono"
+         id="path3869"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 510.75937,4.72 c -0.40006,4.13e-5 -1.64006,-0.8399579 -3.72,-2.52 -2.08005,-1.6799545 -4.12005,-2.51995368 -6.12,-2.52 -2.72004,4.632e-5 -5.56004,0.9600454 -8.52,2.88 -2.88004,1.9200415 -7.64003,5.9200375 -14.28,12 l 0,26.52 21.48,0 c 2.15995,5e-6 3.23995,0.840004 3.24001,2.52 -6e-5,1.600001 -1.08006,2.4 -3.24001,2.4 l -37.92,0 c -2.16001,0 -3.24001,-0.839999 -3.24,-2.52 -10e-6,-1.599996 1.07999,-2.399995 3.24,-2.4 l 11.52001,0 0,-40.2 -9.00001,0 c -2.16001,4.51e-5 -3.24001,-0.83995404 -3.23999,-2.52 -2e-5,-1.5999508 1.07998,-2.39995 3.23999,-2.4 l 13.92,0 0,12.24 c 5.51997,-5.0399572 9.99997,-8.51995368 13.44001,-10.44 3.43995,-1.9999498 6.67995,-2.9999488 9.71999,-3 3.19995,5.12e-5 5.99995,0.9600503 8.40001,2.88 2.39993,1.92004644 3.59993,3.4400449 3.59999,4.56 -6e-5,0.7200431 -0.24006,1.3200425 -0.71999,1.8 -0.48007,0.4800415 -1.08007,0.7200413 -1.80001,0.72"
+         style="font-size:120px;font-variant:normal;font-stretch:normal;font-family:FreeMono;-inkscape-font-specification:FreeMono"
+         id="path3871"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 542.7125,-4.04 0,45.12 19.2,0 c 2.23994,5e-6 3.35994,0.800004 3.36,2.4 -6e-5,1.680001 -1.12006,2.52 -3.36,2.52 l -43.32,0 c -2.16001,0 -3.24001,-0.839999 -3.24,-2.52 -10e-6,-1.599996 1.07999,-2.399995 3.24,-2.4 l 19.2,0 0,-40.2 -14.16,0 c -2.16002,4.51e-5 -3.24002,-0.83995404 -3.24,-2.52 -2e-5,-1.5999508 1.07998,-2.39995 3.24,-2.4 l 19.08,0 m -0.24,-24.84 0,12.48 -7.08,0 0,-12.48 7.08,0"
+         style="font-size:120px;font-variant:normal;font-stretch:normal;font-family:FreeMono;-inkscape-font-specification:FreeMono"
+         id="path3873"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 604.24563,19.72 22.07999,21.36 1.08,0 c 2.15994,5e-6 3.23994,0.800004 3.24,2.4 -6e-5,1.680001 -1.08006,2.52 -3.24,2.52 l -15.84,0 c -2.16004,0 -3.24004,-0.839999 -3.24,-2.52 -4e-5,-1.599996 1.07996,-2.399995 3.24,-2.4 l 7.80001,0 -18.60001,-17.88 -18.84,17.88 8.16001,0 c 2.15997,5e-6 3.23997,0.800004 3.23999,2.4 -2e-5,1.680001 -1.08002,2.52 -3.23999,2.52 l -15.96,0 c -2.16001,0 -3.24001,-0.839999 -3.24001,-2.52 0,-1.599996 1.08,-2.399995 3.24001,-2.4 l 1.08,0 22.07999,-21.36 -19.55999,-18.84 -0.84001,0 c -2.16,4.51e-5 -3.24,-0.83995404 -3.24,-2.52 0,-1.5999508 1.08,-2.39995 3.24,-2.4 l 13.32001,0 c 2.15997,5e-5 3.23997,0.8000492 3.23999,2.4 -2e-5,1.68004596 -1.08002,2.5200451 -3.23999,2.52 l -5.52001,0 16.08,15.6 16.44001,-15.6 -5.76001,0 c -2.16004,4.51e-5 -3.24004,-0.83995404 -3.23999,-2.52 -5e-5,-1.5999508 1.07995,-2.39995 3.23999,-2.4 l 13.2,0 c 2.15994,5e-5 3.23994,0.8000492 3.24,2.4 -6e-5,1.68004596 -1.08006,2.5200451 -3.24,2.52 l -0.84,0 -19.55999,18.84"
+         style="font-size:120px;font-variant:normal;font-stretch:normal;font-family:FreeMono;-inkscape-font-specification:FreeMono"
+         id="path3875"
+         inkscape:connector-curvature="0" />
+    </g>
+  </g>
+</svg>

--- a/http/images/feed.svg
+++ b/http/images/feed.svg
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd"> 
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="128px" height="128px" id="RSSicon" viewBox="0 0 256 256">
+<defs>
+<linearGradient x1="0.085" y1="0.085" x2="0.915" y2="0.915" id="RSSg">
+<stop  offset="0.0" stop-color="#E3702D"/><stop  offset="0.1071" stop-color="#EA7D31"/>
+<stop  offset="0.3503" stop-color="#F69537"/><stop  offset="0.5" stop-color="#FB9E3A"/>
+<stop  offset="0.7016" stop-color="#EA7C31"/><stop  offset="0.8866" stop-color="#DE642B"/>
+<stop  offset="1.0" stop-color="#D95B29"/>
+</linearGradient>
+</defs>
+<rect width="256" height="256" rx="55" ry="55" x="0"  y="0"  fill="#CC5D15"/>
+<rect width="246" height="246" rx="50" ry="50" x="5"  y="5"  fill="#F49C52"/>
+<rect width="236" height="236" rx="47" ry="47" x="10" y="10" fill="url(#RSSg)"/>
+<circle cx="68" cy="189" r="24" fill="#FFF"/>
+<path d="M160 213h-34a82 82 0 0 0 -82 -82v-34a116 116 0 0 1 116 116z" fill="#FFF"/>
+<path d="M184 213A140 140 0 0 0 44 73 V 38a175 175 0 0 1 175 175z" fill="#FFF"/>
+</svg>

--- a/http/index.php
+++ b/http/index.php
@@ -323,6 +323,7 @@ foreach ($xml->drivers->vendor as $vendor) {
         <title><?= Mesamatrix::$config->getValue("info", "title") ?></title>
 
         <link rel="shortcut icon" href="images/gears.png" />
+        <link rel="alternate" type="application/rss+xml" title="rss feed" href="rss.php" />
         <link href="css/style.css?v=<?= Mesamatrix::$config->getValue("info", "version") ?>" rel="stylesheet" type="text/css" media="all"/>
         <link href="css/tipsy.css" rel="stylesheet" type="text/css" media="all" />
         <script src="js/jquery-1.11.3.min.js"></script>
@@ -331,6 +332,12 @@ foreach ($xml->drivers->vendor as $vendor) {
     </head>
     <body>
         <div id="main">
+            <header>
+                <img src="images/banner.svg" class="banner" />
+                <div class="header-icons">
+                    <a href="rss.php"><img src="images/feed.svg" alt="RSS feed" /></a>
+                </div>
+            </header>
             <div class="stats">
                 <div class="stats-commits">
                     <h1>Last commits</h1>

--- a/http/rss.php
+++ b/http/rss.php
@@ -1,0 +1,70 @@
+<?php
+/*
+ * This file is part of mesamatrix.
+ *
+ * Copyright (C) 2015 Robin McCorkell <rmccorkell@karoshi.org.uk>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+require_once "../lib/base.php";
+
+use \Symfony\Component\HttpFoundation\Response as HTTPResponse;
+use \Suin\RSSWriter\Feed as RSSFeed;
+use \Suin\RSSWriter\Channel as RSSChannel;
+use \Suin\RSSWriter\Item as RSSItem;
+
+$gl3Path = \Mesamatrix::path(\Mesamatrix::$config->getValue("info", "xml_file"));
+$xml = simplexml_load_file($gl3Path);
+if (!$xml) {
+    \Mesamatrix::$logger->critical("Can't read ".$gl3Path);
+    exit();
+}
+
+$baseUrl = \Mesamatrix::$request->getSchemeAndHttpHost()
+    . \Mesamatrix::$request->getBasePath();
+
+// prepare RSS
+$rss = new RSSFeed();
+
+$channel = new RSSChannel();
+$channel
+    ->title(\Mesamatrix::$config->getValue("info", "title"))
+    ->description(\Mesamatrix::$config->getValue("info", "description"))
+    ->url($baseUrl)
+    ->appendTo($rss);
+
+$commitWeb = \Mesamatrix::$config->getValue("git", "mesa_web") . "/commit/" 
+    . \Mesamatrix::$config->getValue("git", "gl3") . "?id=";
+
+foreach ($xml->commits->commit as $commit) {
+    $item = new RSSItem();
+    $item
+        ->title((string)$commit["subject"])
+        //->url($commitWeb . $commit["hash"])
+        ->url($baseUrl . '?commit=' . $commit["hash"])
+        ->pubDate((int)$commit["timestamp"])
+        ->appendTo($channel);
+}
+
+// send response
+$response = new HTTPResponse(
+    $rss,
+    HTTPResponse::HTTP_OK,
+    ['Content-Type' => 'text/xml']
+);
+
+$response->prepare(\Mesamatrix::$request);
+$response->send();
+

--- a/lib/base.php
+++ b/lib/base.php
@@ -22,6 +22,7 @@ use Monolog\Logger;
 use Monolog\ErrorHandler;
 use Monolog\Handler\ErrorLogHandler;
 use Monolog\Handler\StreamHandler;
+use Symfony\Component\HttpFoundation\Request as HTTPRequest;
 
 class Mesamatrix
 {
@@ -30,6 +31,7 @@ class Mesamatrix
     public static $config; // Config object
     public static $autoloader; // Autoloader
     public static $logger; // Logger
+    public static $request; // HTTP request object
 
     public static function init() {
         date_default_timezone_set('UTC');
@@ -73,6 +75,9 @@ class Mesamatrix
             ini_set('error_reporting', E_ALL);
             ini_set('display_errors', 1);
         }
+
+        // initialise request
+        self::$request = HTTPRequest::createFromGlobals();
 
         self::$logger->debug('Base initialisation complete');
     }


### PR DESCRIPTION
Quite simple, just presents an RSS feed on `rss.php` that lists the latest commits, with a link back to the main page. RSS link uses GET parameter '?commit=commithash' to make each link unique, and to lay the foundation for highlighting commit changes in the matrix.

New Composer libraries: suin/php-rss-writer to aid creating the RSS tree, and symfony/http-foundation so that parsing GET/POST parameters and request headers is much easier.

Fixes #61 