### PR TITLE
added vendor vivante

### DIFF
--- a/http/css/style.css
+++ b/http/css/style.css
@@ -138,6 +138,7 @@ header .header-icons img.rss {
 .hCellVendor-nvidia     { background-color: #d5f796; }
 .hCellVendor-amd        { background-color: #f7b5b2; }
 .hCellVendor-qualcomm   { background-color: #c7dce8; }
+.hCellVendor-vivante    { background-color: #7dbb46; }
 
 .hCellSep       { width: 0px; }
 

--- a/lib/Parser/Constants.php
+++ b/lib/Parser/Constants.php
@@ -37,7 +37,8 @@ abstract class Constants
         "r600",
         "radeonsi",
         "swr",
-        "freedreno"
+        "freedreno",
+        "etnaviv"
     ];
 
     const ALL_DRIVERS_VENDORS = [
@@ -46,6 +47,7 @@ abstract class Constants
         "Nvidia"    => [ "nv50", "nvc0" ],
         "AMD"       => [ "r600", "radeonsi" ],
         "Qualcomm"  => [ "freedreno" ],
+        "Vivante"   => [ "etnaviv" ],
     ];
 
     // Hints enabling for all drivers.


### PR DESCRIPTION
Like Qualcomm, Vivante is building GPUs for embedded devices. I heard of them because [Purism](https://puri.sm) is considering using the gallium driver `etna_viv` for their Librem 5 phone. Might be interesting for more people to see its status.