### PR TITLE
Add v3d driver

### DIFF
--- a/http/css/style.css
+++ b/http/css/style.css
@@ -141,6 +141,7 @@ header .header-icons img.rss {
 .hCellVendor-amd        { background-color: #f7b5b2; }
 .hCellVendor-qualcomm   { background-color: #c7dce8; }
 .hCellVendor-vivante    { background-color: #a6d87a; }
+.hCellVendor-broadcom   { background-color: #ff006c; }
 
 .hCellSep       { width: 0px; }
 

--- a/lib/Parser/Constants.php
+++ b/lib/Parser/Constants.php
@@ -40,6 +40,7 @@ abstract class Constants
         "freedreno",
         "virgl",
         "etnaviv",
+        "v3d"
     ];
 
     const GL_ALL_DRIVERS_VENDORS = [
@@ -49,6 +50,7 @@ abstract class Constants
         "AMD"       => [ "r600", "radeonsi" ],
         "Qualcomm"  => [ "freedreno" ],
         "Vivante"   => [ "etnaviv" ],
+        "Broadcom"  => [ "v3d" ],
     ];
 
     const VK_ALL_DRIVERS = [


### PR DESCRIPTION
Used as reference commit "Add etnaviv driver" (779336392b)

For the color is the hex value for "Vivid rasberry", as v3d driver is
mostly used with Raspberry 4, and I didn't have any other better idea.