### PR TITLE
Reenable wrapping in commit list

### DIFF
--- a/http/css/style.css
+++ b/http/css/style.css
@@ -72,11 +72,9 @@ header .header-icons img.rss {
     flex: 0 1 50%;
     padding: 0 5px;
 }
-.stats-container > div.stats-item-commits {
-    white-space: nowrap;
-}
 
 .commits th                         { text-align: left; }
+.commits td                         { vertical-align: top; }
 .commits .commitsAge                { padding-right: 2em; }
 .commits .commitsAge::first-letter  { text-transform: uppercase; }
 


### PR DESCRIPTION
Recently long commit lines have been added and they break page layout. This change allows line wrapping and keeps commit dates aligned to the first line.