### PR TITLE
Standardize xml

### DIFF
--- a/lib/Console/Command/Parse.php
+++ b/lib/Console/Command/Parse.php
@@ -482,9 +482,13 @@ class Parse extends \Symfony\Component\Console\Command\Command
             }
         }
 
-        foreach ($glExt->getSubExtensions() as $glSubExt) {
-            $xmlSubExt = $xmlExt->addChild("subextension");
-            $this->generateExtension($xmlSubExt, $glSubExt, $hints);
+        $glSubExts = $glExt->getSubExtensions();
+        if (!empty($glSubExts)) {
+            $xmlSubExts = $xmlExt->addChild("subextensions");
+            foreach ($glSubExts as $glSubExt) {
+                $xmlSubExt = $xmlSubExts->addChild("subextension");
+                $this->generateExtension($xmlSubExt, $glSubExt, $hints);
+            }
         }
     }
 

--- a/lib/Console/Command/Parse.php
+++ b/lib/Console/Command/Parse.php
@@ -260,27 +260,27 @@ class Parse extends \Symfony\Component\Console\Command\Command
         // Write OpenGL API.
         $api = $apis->addChild('api');
         $api->addAttribute('name', 'OpenGL');
-        $this->generateApi($api, $matrix, 'OpenGL');
+        $this->generateApiVersions($api, $matrix, 'OpenGL');
 
         // Write OpenGL ES API.
         $api = $apis->addChild('api');
         $api->addAttribute('name', 'OpenGL ES');
-        $this->generateApi($api, $matrix, 'OpenGL ES');
+        $this->generateApiVersions($api, $matrix, 'OpenGL ES');
 
         // Write OpenGL(ES) extra API.
         $api = $apis->addChild('api');
         $api->addAttribute('name', Constants::GL_OR_ES_EXTRA_NAME);
-        $this->generateApi($api, $matrix, Constants::GL_OR_ES_EXTRA_NAME);
+        $this->generateApiVersions($api, $matrix, Constants::GL_OR_ES_EXTRA_NAME);
 
         // Write Vulkan API.
         $api = $apis->addChild('api');
         $api->addAttribute('name', 'Vulkan');
-        $this->generateApi($api, $matrix, 'Vulkan');
+        $this->generateApiVersions($api, $matrix, 'Vulkan');
 
         // Write Vulkan extra API.
         $api = $apis->addChild('api');
         $api->addAttribute('name', Constants::VK_EXTRA_NAME);
-        $this->generateApi($api, $matrix, Constants::VK_EXTRA_NAME);
+        $this->generateApiVersions($api, $matrix, Constants::VK_EXTRA_NAME);
 
         // Write file.
         $xmlPath = \Mesamatrix::path(\Mesamatrix::$config->getValue('info', 'private_dir'))
@@ -337,31 +337,31 @@ class Parse extends \Symfony\Component\Console\Command\Command
         $api = $apis->addChild('api');
         $api->addAttribute('name', 'OpenGL');
         $this->populateGlVendors($api);
-        $this->generateApi($api, $matrix, 'OpenGL');
+        $this->generateApiVersions($api, $matrix, 'OpenGL');
 
         // Generate for OpenGL ES.
         $api = $apis->addChild('api');
         $api->addAttribute('name', 'OpenGL ES');
         $this->populateGlVendors($api); // Uses the same drivers as OpenGL.
-        $this->generateApi($api, $matrix, 'OpenGL ES');
+        $this->generateApiVersions($api, $matrix, 'OpenGL ES');
 
         // Generate for OpenGL(ES) extra.
         $api = $apis->addChild('api');
         $api->addAttribute('name', Constants::GL_OR_ES_EXTRA_NAME);
         $this->populateGlVendors($api); // Uses the same drivers as OpenGL.
-        $this->generateApi($api, $matrix, Constants::GL_OR_ES_EXTRA_NAME);
+        $this->generateApiVersions($api, $matrix, Constants::GL_OR_ES_EXTRA_NAME);
 
         // Generate for Vulkan.
         $api = $apis->addChild('api');
         $api->addAttribute('name', 'Vulkan');
         $this->populateVulkanVendors($api);
-        $this->generateApi($api, $matrix, 'Vulkan');
+        $this->generateApiVersions($api, $matrix, 'Vulkan');
 
         // Generate for Vulkan (extra).
         $api = $apis->addChild('api');
         $api->addAttribute('name', Constants::VK_EXTRA_NAME);
         $this->populateVulkanVendors($api);
-        $this->generateApi($api, $matrix, Constants::VK_EXTRA_NAME);
+        $this->generateApiVersions($api, $matrix, Constants::VK_EXTRA_NAME);
 
         $xmlPath = \Mesamatrix::path(\Mesamatrix::$config->getValue("info", "xml_file"));
 
@@ -410,10 +410,11 @@ class Parse extends \Symfony\Component\Console\Command\Command
         }
     }
 
-    protected function generateApi(\SimpleXMLElement $api, OglMatrix $matrix, $name) {
+    protected function generateApiVersions(\SimpleXMLElement $api, OglMatrix $matrix, $name) {
+        $xmlVersions = $api->addChild("versions");
         foreach ($matrix->getGlVersions() as $glVersion) {
             if ($glVersion->getGlName() === $name) {
-                $version = $api->addChild('version');
+                $version = $xmlVersions->addChild('version');
                 $this->generateGlVersion($version, $glVersion, $matrix->getHints());
             }
         }

--- a/lib/Console/Command/Parse.php
+++ b/lib/Console/Command/Parse.php
@@ -467,9 +467,9 @@ class Parse extends \Symfony\Component\Console\Command\Command
             $modified->addChild("author", $commit->getAuthor());
         }
 
-        $supported = $xmlExt->addChild("supported");
+        $supportedDrivers = $xmlExt->addChild("supported-drivers");
         foreach ($glExt->getSupportedDrivers() as $glDriver) {
-            $driver = $supported->addChild($glDriver->getName());
+            $driver = $supportedDrivers->addChild($glDriver->getName());
             $hintId = $glDriver->getHintIdx();
             if ($hintId !== -1) {
                 $driver->addAttribute("hint", $hints->allHints[$hintId]);

--- a/lib/Console/Command/Parse.php
+++ b/lib/Console/Command/Parse.php
@@ -423,9 +423,10 @@ class Parse extends \Symfony\Component\Console\Command\Command
     protected function generateGlVersion(\SimpleXMLElement $version, OglVersion $glVersion, Hints $hints) {
         $version->addAttribute("name", $glVersion->getGlName());
         $version->addAttribute("version", $glVersion->getGlVersion());
-        $glsl = $version->addChild("glsl");
-        $glsl->addAttribute("name", $glVersion->getGlslName());
-        $glsl->addAttribute("version", $glVersion->getGlslVersion());
+
+        $shaderVersion = $version->addChild("shader-version");
+        $shaderVersion->addAttribute("name", $glVersion->getGlslName());
+        $shaderVersion->addAttribute("version", $glVersion->getGlslVersion());
 
         $extensions = $version->addChild("extensions");
         foreach ($glVersion->getExtensions() as $glExt) {

--- a/lib/Console/Command/Parse.php
+++ b/lib/Console/Command/Parse.php
@@ -336,31 +336,31 @@ class Parse extends \Symfony\Component\Console\Command\Command
         // Generate for OpenGL.
         $api = $apis->addChild('api');
         $api->addAttribute('name', 'OpenGL');
-        $this->populateGlDrivers($api);
+        $this->populateGlVendors($api);
         $this->generateApi($api, $matrix, 'OpenGL');
 
         // Generate for OpenGL ES.
         $api = $apis->addChild('api');
         $api->addAttribute('name', 'OpenGL ES');
-        $this->populateGlDrivers($api); // Uses the same drivers as OpenGL.
+        $this->populateGlVendors($api); // Uses the same drivers as OpenGL.
         $this->generateApi($api, $matrix, 'OpenGL ES');
 
         // Generate for OpenGL(ES) extra.
         $api = $apis->addChild('api');
         $api->addAttribute('name', Constants::GL_OR_ES_EXTRA_NAME);
-        $this->populateGlDrivers($api); // Uses the same drivers as OpenGL.
+        $this->populateGlVendors($api); // Uses the same drivers as OpenGL.
         $this->generateApi($api, $matrix, Constants::GL_OR_ES_EXTRA_NAME);
 
         // Generate for Vulkan.
         $api = $apis->addChild('api');
         $api->addAttribute('name', 'Vulkan');
-        $this->populateVulkanDrivers($api);
+        $this->populateVulkanVendors($api);
         $this->generateApi($api, $matrix, 'Vulkan');
 
         // Generate for Vulkan (extra).
         $api = $apis->addChild('api');
         $api->addAttribute('name', Constants::VK_EXTRA_NAME);
-        $this->populateVulkanDrivers($api);
+        $this->populateVulkanVendors($api);
         $this->generateApi($api, $matrix, Constants::VK_EXTRA_NAME);
 
         $xmlPath = \Mesamatrix::path(\Mesamatrix::$config->getValue("info", "xml_file"));
@@ -388,22 +388,23 @@ class Parse extends \Symfony\Component\Console\Command\Command
         }
     }
 
-    protected function populateGlDrivers(\SimpleXMLElement $xmlParent) {
-        $xmlDrivers = $xmlParent->addChild("drivers");
-        $this->populateDrivers($xmlDrivers, Constants::GL_ALL_DRIVERS_VENDORS);
+    protected function populateGlVendors(\SimpleXMLElement $xmlParent) {
+        $xmlVendors = $xmlParent->addChild("vendors");
+        $this->populateDrivers($xmlVendors, Constants::GL_ALL_DRIVERS_VENDORS);
     }
 
-    protected function populateVulkanDrivers(\SimpleXMLElement $xmlParent) {
-        $xmlDrivers = $xmlParent->addChild("drivers");
-        $this->populateDrivers($xmlDrivers, Constants::VK_ALL_DRIVERS_VENDORS);
+    protected function populateVulkanVendors(\SimpleXMLElement $xmlParent) {
+        $xmlVendors = $xmlParent->addChild("vendors");
+        $this->populateDrivers($xmlVendors, Constants::VK_ALL_DRIVERS_VENDORS);
     }
 
-    protected function populateDrivers(\SimpleXMLElement $xmlDrivers, array $vendors) {
+    protected function populateDrivers(\SimpleXMLElement $xmlVendors, array $vendors) {
         foreach ($vendors as $vendor => $drivers) {
-            $xmlVendor = $xmlDrivers->addChild("vendor");
+            $xmlVendor = $xmlVendors->addChild("vendor");
             $xmlVendor->addAttribute("name", $vendor);
+            $xmlDrivers = $xmlVendor->addChild("drivers");
             foreach ($drivers as $driver) {
-                $xmlDriver = $xmlVendor->addChild("driver");
+                $xmlDriver = $xmlDrivers->addChild("driver");
                 $xmlDriver->addAttribute("name", $driver);
             }
         }

--- a/lib/Console/Command/Parse.php
+++ b/lib/Console/Command/Parse.php
@@ -427,8 +427,9 @@ class Parse extends \Symfony\Component\Console\Command\Command
         $glsl->addAttribute("name", $glVersion->getGlslName());
         $glsl->addAttribute("version", $glVersion->getGlslVersion());
 
+        $extensions = $version->addChild("extensions");
         foreach ($glVersion->getExtensions() as $glExt) {
-            $ext = $version->addChild("extension");
+            $ext = $extensions->addChild("extension");
             $this->generateExtension($ext, $glExt, $hints);
         }
     }

--- a/lib/Console/Command/Parse.php
+++ b/lib/Console/Command/Parse.php
@@ -469,7 +469,8 @@ class Parse extends \Symfony\Component\Console\Command\Command
 
         $supportedDrivers = $xmlExt->addChild("supported-drivers");
         foreach ($glExt->getSupportedDrivers() as $glDriver) {
-            $driver = $supportedDrivers->addChild($glDriver->getName());
+            $driver = $supportedDrivers->addChild("driver");
+            $driver->addAttribute("name", $glDriver->getName());
             $hintId = $glDriver->getHintIdx();
             if ($hintId !== -1) {
                 $driver->addAttribute("hint", $hints->allHints[$hintId]);

--- a/lib/Controller/ApiSubController.php
+++ b/lib/Controller/ApiSubController.php
@@ -231,7 +231,8 @@ class ApiSubController
 
             foreach ($xmlVersion->extensions->extension as $xmlExt) {
                 $this->addExtension($subsection, $xmlExt, false, $vendors);
-                foreach ($xmlExt->subextension as $xmlSubExt)
+                $xmlSubExts = $xmlExt->xpath('./subextensions/subextension');
+                foreach ($xmlSubExts as $xmlSubExt)
                     $this->addExtension($subsection, $xmlSubExt, true, $vendors);
             }
         }

--- a/lib/Controller/ApiSubController.php
+++ b/lib/Controller/ApiSubController.php
@@ -273,15 +273,16 @@ class ApiSubController
                 $driverName = (string) $driver['name'];
 
                 $extTask = array();
-                $driverNode = $xmlExt->{'supported-drivers'}->{$driverName};
-                if ($driverNode) {
+                $xmlSupportedDrivers = $xmlExt->xpath("./supported-drivers/driver[@name='${driverName}']");
+                $xmlSupportedDriver = !empty($xmlSupportedDrivers) ? $xmlSupportedDrivers[0] : null;
+                if ($xmlSupportedDriver) {
                     $extTask['class'] = 'isDone';
-                    $extTask['timestamp'] = (int) $driverNode->modified->date;
+                    $extTask['timestamp'] = (int) $xmlSupportedDriver->modified->date;
+                    $extTask['hint'] = $xmlSupportedDriver['hint'];
                 }
                 else {
                     $extTask['class'] = 'isNotStarted';
                 }
-                $extTask['hint'] = $driverNode['hint'];
                 $extension['tasks'][$driverName] = $extTask;
             }
         }

--- a/lib/Controller/ApiSubController.php
+++ b/lib/Controller/ApiSubController.php
@@ -166,7 +166,7 @@ class ApiSubController
 
     private function addApiSection(array &$matrix, \SimpleXmlElement $xmlApi) {
         $glVersions = array();
-        foreach ($xmlApi->version as $glVersion) {
+        foreach ($xmlApi->versions->version as $glVersion) {
             $glVersions[] = $glVersion;
         }
 

--- a/lib/Controller/ApiSubController.php
+++ b/lib/Controller/ApiSubController.php
@@ -273,7 +273,7 @@ class ApiSubController
                 $driverName = (string) $driver['name'];
 
                 $extTask = array();
-                $driverNode = $xmlExt->supported->{$driverName};
+                $driverNode = $xmlExt->{'supported-drivers'}->{$driverName};
                 if ($driverNode) {
                     $extTask['class'] = 'isDone';
                     $extTask['timestamp'] = (int) $driverNode->modified->date;

--- a/lib/Controller/ApiSubController.php
+++ b/lib/Controller/ApiSubController.php
@@ -116,14 +116,14 @@ class ApiSubController
         // Get all the vendors and all their drivers.
         $vendors = array();
         foreach ($xmlApis as $xmlApi) {
-            foreach ($xmlApi->drivers->vendor as $vendor) {
+            foreach ($xmlApi->vendors->vendor as $vendor) {
                 $vendorName = (string) $vendor['name'];
                 if (!array_key_exists($vendorName, $vendors)) {
                     $vendors[$vendorName] = array();
                 }
 
                 $driverNames = &$vendors[$vendorName];
-                foreach ($vendor->driver as $driver) {
+                foreach ($vendor->drivers->driver as $driver) {
                     $driverName = (string) $driver['name'];
                     if (!in_array($driverName, $driverNames)) {
                         $driverNames[] = $driverName;
@@ -189,13 +189,13 @@ class ApiSubController
         );
 
         foreach ($glVersions as $glVersion) {
-            $this->addSection($api, $glVersion, $xmlApi->drivers);
+            $this->addSection($api, $glVersion, $xmlApi->vendors);
         }
 
         $matrix['sections'][] = $api;
     }
 
-    private function addSection(array &$section, \SimpleXMLElement $glSection, \SimpleXMLElement $drivers) {
+    private function addSection(array &$section, \SimpleXMLElement $glSection, \SimpleXMLElement $vendors) {
         $text = "";
         if (!empty($glSection['version'])) {
             $text = $glSection['name'];
@@ -220,8 +220,8 @@ class ApiSubController
 
             $driverScores = array();
             $driverScores['mesa'] = $numGlVersionExts !== 0 ? $lbGlVersion->getNumDriverExtsDone('mesa') / $numGlVersionExts : 0;
-            foreach ($drivers->vendor as $vendor) {
-                foreach ($vendor->driver as $driver) {
+            foreach ($vendors->vendor as $vendor) {
+                foreach ($vendor->drivers->driver as $driver) {
                     $driverName = (string) $driver['name'];
                     $driverScores[$driverName] = $numGlVersionExts !== 0 ? $lbGlVersion->getNumDriverExtsDone($driverName) / $numGlVersionExts : 0;
                 }
@@ -230,16 +230,16 @@ class ApiSubController
             $subsection['scores'] = $driverScores;
 
             foreach ($glSection->extension as $glExt) {
-                $this->addExtension($subsection, $glExt, false, $drivers);
+                $this->addExtension($subsection, $glExt, false, $vendors);
                 foreach ($glExt->subextension as $glSubExt)
-                    $this->addExtension($subsection, $glSubExt, true, $drivers);
+                    $this->addExtension($subsection, $glSubExt, true, $vendors);
             }
         }
 
         $section['subsections'][] = $subsection;
     }
 
-    private function addExtension(array &$subsection, \SimpleXMLElement $glExt, $isSubExt, \SimpleXMLElement $drivers) {
+    private function addExtension(array &$subsection, \SimpleXMLElement $glExt, $isSubExt, \SimpleXMLElement $vendors) {
         $extension = array(
             'name' => $glExt['name'],
         );
@@ -267,8 +267,8 @@ class ApiSubController
         $extTask['hint'] = $glExt->mesa['hint'];
         $extension['tasks']['mesa'] = $extTask;
 
-        foreach ($drivers->vendor as $vendor) {
-            foreach ($vendor->driver as $driver) {
+        foreach ($vendors->vendor as $vendor) {
+            foreach ($vendor->drivers->driver as $driver) {
                 $driverName = (string) $driver['name'];
 
                 $extTask = array();

--- a/lib/Controller/ApiSubController.php
+++ b/lib/Controller/ApiSubController.php
@@ -202,8 +202,9 @@ class ApiSubController
             if (!empty((string) $xmlVersion['version'])) {
                 $text .= ' '.$xmlVersion['version'];
             }
-            if (!empty((string) $xmlVersion->glsl['name'])) {
-                $text .= ' - '.$xmlVersion->glsl['name'].' '.$xmlVersion->glsl['version'];
+            $xmlShaderVersion = $xmlVersion->{'shader-version'};
+            if (!empty((string) $xmlShaderVersion['name'])) {
+                $text .= ' - '.$xmlShaderVersion['name'].' '.$xmlShaderVersion['version'];
             }
         }
 

--- a/lib/Leaderboard.php
+++ b/lib/Leaderboard.php
@@ -98,8 +98,8 @@ class Leaderboard {
             $lbGlVersion->addDriver("mesa", $numDoneExts);
 
             // Count done extensions and sub-extensions for each drivers.
-            foreach ($api->drivers->vendor as $vendor) {
-                foreach ($vendor->driver as $driver) {
+            foreach ($api->vendors->vendor as $vendor) {
+                foreach ($vendor->drivers->driver as $driver) {
                     $driverName = (string) $driver["name"];
 
                     // Count done extensions and sub-extensions for $driverName.

--- a/lib/Leaderboard.php
+++ b/lib/Leaderboard.php
@@ -67,29 +67,31 @@ class Leaderboard {
      * @param SimpleXMLElement $api The XML tag for the wanted API.
      */
     private function loadApi(\SimpleXMLElement $api) {
-        foreach($api->versions->version as $glVersion) {
-            $lbGlVersion = $this->createGlVersion((string) $glVersion["name"],
-                                                  (string) $glVersion["version"]);
+        foreach($api->versions->version as $xmlVersion) {
+            $lbGlVersion = $this->createGlVersion((string) $xmlVersion["name"],
+                                                  (string) $xmlVersion["version"]);
 
             // Count total extensions and sub-extensions.
-            $numTotalExts = count($glVersion->extensions->extension);
-            foreach ($glVersion->extensions->extension as $glExt) {
-                $numTotalExts += count($glExt->subextension);
+            $numTotalExts = count($xmlVersion->extensions->extension);
+            foreach ($xmlVersion->extensions->extension as $xmlExt) {
+                $xmlSubExts = $xmlExt->xpath('./subextensions/subextension');
+                $numTotalExts += count($xmlSubExts);
             }
 
             $lbGlVersion->setNumExts($numTotalExts);
 
             // Count done mesa extensions and sub-extensions.
             $numDoneExts = 0;
-            foreach ($glVersion->extensions->extension as $glExt) {
+            foreach ($xmlVersion->extensions->extension as $xmlExt) {
                 // Extension.
-                if ($glExt->mesa["status"] == Parser\Constants::STATUS_DONE) {
+                if ($xmlExt->mesa["status"] == Parser\Constants::STATUS_DONE) {
                     $numDoneExts += 1;
                 }
 
                 // Sub-extensions.
-                foreach ($glExt->subextension as $glSubExt) {
-                    if ($glSubExt->mesa["status"] == Parser\Constants::STATUS_DONE) {
+                $xmlSubExts = $xmlExt->xpath('./subextensions/subextension');
+                foreach ($xmlSubExts as $xmlSubExt) {
+                    if ($xmlSubExt->mesa["status"] == Parser\Constants::STATUS_DONE) {
                         $numDoneExts += 1;
                     }
                 }
@@ -104,15 +106,16 @@ class Leaderboard {
 
                     // Count done extensions and sub-extensions for $driverName.
                     $numDoneExts = 0;
-                    foreach ($glVersion->extensions->extension as $glExt) {
+                    foreach ($xmlVersion->extensions->extension as $xmlExt) {
                         // Extension.
-                        if ($glExt->supported->{$driverName}) {
+                        if ($xmlExt->supported->{$driverName}) {
                             $numDoneExts += 1;
                         }
 
                         // Sub-extensions.
-                        foreach ($glExt->subextension as $glSubExt) {
-                            if ($glSubExt->supported->{$driverName}) {
+                        $xmlSubExts = $xmlExt->xpath('./subextensions/subextension');
+                        foreach ($xmlSubExts as $xmlSubExt) {
+                            if ($xmlSubExt->supported->{$driverName}) {
                                 $numDoneExts += 1;
                             }
                         }

--- a/lib/Leaderboard.php
+++ b/lib/Leaderboard.php
@@ -108,14 +108,18 @@ class Leaderboard {
                     $numDoneExts = 0;
                     foreach ($xmlVersion->extensions->extension as $xmlExt) {
                         // Extension.
-                        if ($xmlExt->{'supported-drivers'}->{$driverName}) {
+                        $xmlSupportedDrivers = $xmlExt->xpath("./supported-drivers/driver[@name='${driverName}']");
+                        $xmlSupportedDriver = !empty($xmlSupportedDrivers) ? $xmlSupportedDrivers[0] : null;
+                        if ($xmlSupportedDriver) {
                             $numDoneExts += 1;
                         }
 
                         // Sub-extensions.
                         $xmlSubExts = $xmlExt->xpath('./subextensions/subextension');
                         foreach ($xmlSubExts as $xmlSubExt) {
-                            if ($xmlSubExt->{'supported-drivers'}->{$driverName}) {
+                            $xmlSupportedDrivers = $xmlSubExt->xpath("./supported-drivers/driver[@name='${driverName}']");
+                            $xmlSupportedDriver = !empty($xmlSupportedDrivers) ? $xmlSupportedDrivers[0] : null;
+                            if ($xmlSupportedDriver) {
                                 $numDoneExts += 1;
                             }
                         }

--- a/lib/Leaderboard.php
+++ b/lib/Leaderboard.php
@@ -67,7 +67,7 @@ class Leaderboard {
      * @param SimpleXMLElement $api The XML tag for the wanted API.
      */
     private function loadApi(\SimpleXMLElement $api) {
-        foreach($api->version as $glVersion) {
+        foreach($api->versions->version as $glVersion) {
             $lbGlVersion = $this->createGlVersion((string) $glVersion["name"],
                                                   (string) $glVersion["version"]);
 

--- a/lib/Leaderboard.php
+++ b/lib/Leaderboard.php
@@ -108,14 +108,14 @@ class Leaderboard {
                     $numDoneExts = 0;
                     foreach ($xmlVersion->extensions->extension as $xmlExt) {
                         // Extension.
-                        if ($xmlExt->supported->{$driverName}) {
+                        if ($xmlExt->{'supported-drivers'}->{$driverName}) {
                             $numDoneExts += 1;
                         }
 
                         // Sub-extensions.
                         $xmlSubExts = $xmlExt->xpath('./subextensions/subextension');
                         foreach ($xmlSubExts as $xmlSubExt) {
-                            if ($xmlSubExt->supported->{$driverName}) {
+                            if ($xmlSubExt->{'supported-drivers'}->{$driverName}) {
                                 $numDoneExts += 1;
                             }
                         }

--- a/lib/Leaderboard.php
+++ b/lib/Leaderboard.php
@@ -72,8 +72,8 @@ class Leaderboard {
                                                   (string) $glVersion["version"]);
 
             // Count total extensions and sub-extensions.
-            $numTotalExts = count($glVersion->extension);
-            foreach ($glVersion->extension as $glExt) {
+            $numTotalExts = count($glVersion->extensions->extension);
+            foreach ($glVersion->extensions->extension as $glExt) {
                 $numTotalExts += count($glExt->subextension);
             }
 
@@ -81,7 +81,7 @@ class Leaderboard {
 
             // Count done mesa extensions and sub-extensions.
             $numDoneExts = 0;
-            foreach ($glVersion->extension as $glExt) {
+            foreach ($glVersion->extensions->extension as $glExt) {
                 // Extension.
                 if ($glExt->mesa["status"] == Parser\Constants::STATUS_DONE) {
                     $numDoneExts += 1;
@@ -104,7 +104,7 @@ class Leaderboard {
 
                     // Count done extensions and sub-extensions for $driverName.
                     $numDoneExts = 0;
-                    foreach ($glVersion->extension as $glExt) {
+                    foreach ($glVersion->extensions->extension as $glExt) {
                         // Extension.
                         if ($glExt->supported->{$driverName}) {
                             $numDoneExts += 1;

--- a/lib/Parser/OglExtension.php
+++ b/lib/Parser/OglExtension.php
@@ -267,7 +267,7 @@ class OglExtension
             $subExtHint = (string) $xmlSubExt->mesa['hint'];
 
             $newSubExtension = new OglExtension($subExtName, $subExtStatus, $subExtHint, $this->hints, array());
-            foreach ($xmlSubExt->supported->children() as $driver) {
+            foreach ($xmlSubExt->{'supported-drivers'}->children() as $driver) {
                 // Create new supported driver.
                 $driverName = $driver->getName();
                 $driverHint = (string) $driver['hint'];

--- a/lib/Parser/OglExtension.php
+++ b/lib/Parser/OglExtension.php
@@ -238,7 +238,7 @@ class OglExtension
     }
 
     public function merge(OglVersion $glSection, \SimpleXMLElement $xmlExt, \Mesamatrix\Git\Commit $commit) {
-        $xmlSubExts = $xmlExt->xpath('./subextension');
+        $xmlSubExts = $xmlExt->xpath('./subextensions/subextension');
 
         // Remove old sub-extensions.
         $numXmlSubExts = count($xmlSubExts);

--- a/lib/Parser/OglExtension.php
+++ b/lib/Parser/OglExtension.php
@@ -267,10 +267,12 @@ class OglExtension
             $subExtHint = (string) $xmlSubExt->mesa['hint'];
 
             $newSubExtension = new OglExtension($subExtName, $subExtStatus, $subExtHint, $this->hints, array());
-            foreach ($xmlSubExt->{'supported-drivers'}->children() as $driver) {
+            $xmlSupportedDrivers = $xmlSubExt->xpath("./supported-drivers/driver");
+            foreach ($xmlSupportedDrivers as $xmlSupportedDriver) {
                 // Create new supported driver.
-                $driverName = $driver->getName();
-                $driverHint = (string) $driver['hint'];
+                $driverName = (string) $xmlSupportedDriver['name'];
+                $driverHint = (string) $xmlSupportedDriver['hint'];
+
                 $driver = new OglSupportedDriver($driverName, $this->hints);
                 $driver->setHint($driverHint);
                 $newSubExtension->addSupportedDriver($driver, $commit);

--- a/lib/Parser/OglMatrix.php
+++ b/lib/Parser/OglMatrix.php
@@ -136,10 +136,11 @@ class OglMatrix
 
             $glSection = $this->getGlVersionByName($glName, $glVersion);
             if (!$glSection) {
-                $glslName = (string) $xmlSection->glsl['name'];
-                $glslVersion = (string) $xmlSection->glsl['version'];
+                $xmlShaderVersion = $xmlSection->{'shader-version'};
+                $shaderName = (string) $xmlShaderVersion['name'];
+                $shaderVersion = (string) $xmlShaderVersion['version'];
 
-                $glSection = new OglVersion($glName, $glVersion, $glslName, $glslVersion, $this->getHints());
+                $glSection = new OglVersion($glName, $glVersion, $shaderName, $shaderVersion, $this->getHints());
                 $this->addGlVersion($glSection);
             }
 

--- a/lib/Parser/OglMatrix.php
+++ b/lib/Parser/OglMatrix.php
@@ -101,7 +101,7 @@ class OglMatrix
     }
 
     private function mergeApi(\SimpleXMLElement $api, \Mesamatrix\Git\Commit $commit) {
-        $xmlSections = $api->version;
+        $xmlSections = $api->versions->version;
 
         // Remove old sections.
         $numXmlSections = count($xmlSections);

--- a/lib/Parser/OglVersion.php
+++ b/lib/Parser/OglVersion.php
@@ -189,7 +189,7 @@ class OglVersion
             $extHint = (string) $xmlExt->mesa['hint'];
 
             $newExtension = new OglExtension($extName, $extStatus, $extHint, $this->hints, array());
-            foreach ($xmlExt->supported->children() as $driver) {
+            foreach ($xmlExt->{'supported-drivers'}->children() as $driver) {
                 // Get driver name and verify it's valid.
                 $driverName = $driver->getName();
                 if (!in_array($driverName, $apiDrivers)) {

--- a/lib/Parser/OglVersion.php
+++ b/lib/Parser/OglVersion.php
@@ -158,7 +158,7 @@ class OglVersion
     }
 
     public function merge(\SimpleXMLElement $xmlSection, \Mesamatrix\Git\Commit $commit) {
-        $xmlExts = $xmlSection->xpath('./extension');
+        $xmlExts = $xmlSection->extensions->extension;
 
         // Remove old extensions.
         $glName = $this->getGlName();

--- a/lib/Parser/OglVersion.php
+++ b/lib/Parser/OglVersion.php
@@ -189,16 +189,18 @@ class OglVersion
             $extHint = (string) $xmlExt->mesa['hint'];
 
             $newExtension = new OglExtension($extName, $extStatus, $extHint, $this->hints, array());
-            foreach ($xmlExt->{'supported-drivers'}->children() as $driver) {
+            $xmlSupportedDrivers = $xmlExt->xpath("./supported-drivers/driver");
+            foreach ($xmlSupportedDrivers as $xmlSupportedDriver) {
                 // Get driver name and verify it's valid.
-                $driverName = $driver->getName();
+                $driverName = (string) $xmlSupportedDriver['name'];
                 if (!in_array($driverName, $apiDrivers)) {
                     \Mesamatrix::$logger->error('Unrecognized driver: '.$driverName);
                     continue;
                 }
 
                 // Create new supported driver.
-                $driverHint = (string) $driver['hint'];
+                $driverHint = (string) $xmlSupportedDriver['hint'];
+
                 $driver = new OglSupportedDriver($driverName, $this->hints);
                 $driver->setHint($driverHint);
                 $newExtension->addSupportedDriver($driver, $commit);


### PR DESCRIPTION
Changed some XML tags and their hierarchies in order to have a more standardized XML.

For instance, instead of this:
```xml
<supported>
  <freedreno />
</supported>
```
It is now this:
```xml
<supported-drivers>
  <driver name="freedreno" />
</supported-drivers>
```

I discovered this was an issue when I tried to parse the features.xml with the C# serializer.