### PR TITLE
List vc4 before v3d, chronologically

### DIFF
--- a/lib/Parser/Constants.php
+++ b/lib/Parser/Constants.php
@@ -40,8 +40,8 @@ abstract class Constants
         "freedreno",
         "virgl",
         "etnaviv",
-        "v3d",
         "vc4",
+        "v3d",
         "zink",
         "panfrost",
         "d3d12",
@@ -54,7 +54,7 @@ abstract class Constants
         "AMD"       => [ "r600", "radeonsi" ],
         "Qualcomm"  => [ "freedreno" ],
         "Vivante"   => [ "etnaviv" ],
-        "Broadcom"  => [ "v3d", "vc4" ],
+        "Broadcom"  => [ "vc4", "v3d" ],
         "Arm"       => [ "panfrost" ],
         "Emulation" => [ "d3d12", "virgl", "zink" ],
     ];


### PR DESCRIPTION
V3D hardware is a successor of VC4. The other such pairs (nv50/nvc0 and r600/radeonsi) list the older version first, resulting their table section being ordered left->right. Do the same for consistency.