### PR TITLE
Add lima driver

### DIFF
--- a/lib/Parser/Constants.php
+++ b/lib/Parser/Constants.php
@@ -43,6 +43,7 @@ abstract class Constants
         "vc4",
         "v3d",
         "zink",
+        "lima",
         "panfrost",
         "d3d12",
     ];
@@ -55,7 +56,7 @@ abstract class Constants
         "Qualcomm"  => [ "freedreno" ],
         "Vivante"   => [ "etnaviv" ],
         "Broadcom"  => [ "vc4", "v3d" ],
-        "Arm"       => [ "panfrost" ],
+        "Arm"       => [ "lima", "panfrost" ],
         "Emulation" => [ "d3d12", "virgl", "zink" ],
     ];
 


### PR DESCRIPTION
Note that lima is primarily a GLES2 driver, so it is not expected it will cover much of the GLES3+ extension space.
But it is useful to have it listed there anyway since it is also part of mesa and gains some extension support from it.

Needs this to be merged to mesa first: https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/9031