### PR TITLE
Parse the latest commit and define history from there

### DIFF
--- a/lib/Controller/ApiSubController.php
+++ b/lib/Controller/ApiSubController.php
@@ -246,7 +246,11 @@ class ApiSubController
         $section['subsections'][] = $subsection;
     }
 
-    private function addExtension(array &$subsection, \SimpleXMLElement $xmlExt, $isSubExt, \SimpleXMLElement $vendors) {
+    private function addExtension(
+        array &$subsection,
+        \SimpleXMLElement $xmlExt,
+        bool $isSubExt,
+        \SimpleXMLElement $vendors) {
         $extension = array(
             'name' => $xmlExt['name'],
         );
@@ -283,7 +287,8 @@ class ApiSubController
                 $xmlSupportedDriver = !empty($xmlSupportedDrivers) ? $xmlSupportedDrivers[0] : null;
                 if ($xmlSupportedDriver) {
                     $extTask['class'] = 'isDone';
-                    $extTask['timestamp'] = (int) $xmlSupportedDriver->modified->date;
+                    if (!empty($xmlSupportedDriver->modified))
+                        $extTask['timestamp'] = (int) $xmlSupportedDriver->modified->date;
                     $extTask['hint'] = $xmlSupportedDriver['hint'];
                 }
                 else {
@@ -418,23 +423,23 @@ foreach($this->matrix['sections'] as $section):
 <?php
                 elseif ($col['type'] === 'driver'):
                     $driverTask = $extension['tasks'][$col['name']];
-                    $cssClasses = array($driverTask['class']);
+                    $cssClasses = array('task', $driverTask['class']);
                     $title = '';
                     if (isset($driverTask['hint'])):
                         $cssClasses[] = 'footnote';
                         $title = ' title="'.$driverTask['hint'].'"';
                     endif;
+?>
+            <td class="<?= join(' ', $cssClasses) ?>"<?= $title ?>>
+<?php
                     if (isset($driverTask['timestamp'])):
 ?>
-            <td class="task <?= join(' ', $cssClasses) ?>"<?= $title ?>>
                 <span data-timestamp="<?= $driverTask['timestamp'] ?>"><?= date('Y-m-d', $driverTask['timestamp']) ?></span>
-            </td>
-<?php
-                    else:
-?>
-            <td class="task <?= $driverTask['class'] ?>"></td>
 <?php
                     endif;
+?>
+            </td>
+<?php
                 else:
 ?>
             <td></td>

--- a/lib/Git/Commit.php
+++ b/lib/Git/Commit.php
@@ -49,6 +49,11 @@ class Commit
         return $this;
     }
 
+    /**
+     * Get the commit date.
+     *
+     * @return \DateTime The commit date.
+     */
     public function getDate() {
         return $this->date;
     }

--- a/lib/Parser/Constants.php
+++ b/lib/Parser/Constants.php
@@ -107,7 +107,6 @@ abstract class Constants
     // 1: use hint?
     const RE_ALL_DRIVERS_HINTS = [
         [ "/^all drivers$/i", FALSE ],
-        [ "/^0 binary formats$/i", TRUE ],
         [ "/^all drivers that support GLSL( \d+\.\d+\+?)?$/i", TRUE ],
         [ "/^all - but needs GLX\/EGL extension to be useful$/i", TRUE ],
     ];

--- a/lib/Parser/OglMatrix.php
+++ b/lib/Parser/OglMatrix.php
@@ -22,8 +22,8 @@ namespace Mesamatrix\Parser;
 
 class OglMatrix
 {
-    private $glVersions;
-    private $hints;
+    private array $glVersions;
+    private Hints $hints;
 
     public function __construct() {
         $this->glVersions = array();
@@ -32,13 +32,6 @@ class OglMatrix
 
     public function addGlVersion(OglVersion $glVersion) {
         array_push($this->glVersions, $glVersion);
-    }
-
-    public function removeGlVersion(OglVersion $glVersion) {
-        $idx = array_search($glVersion, $this->glVersions);
-        if ($idx !== false) {
-            array_splice($this->glVersions, $idx, 1);
-        }
     }
 
     /**
@@ -87,71 +80,52 @@ class OglMatrix
     }
 
     /**
-     * Merge an XML formatted commit.
+     * Load an XML formatted commit.
      *
      * @param \SimpleXMLElement $mesa The root element of the XML file.
-     * @param \Mesamatrix\Git\Commit $commit The commit used by the parser.
-     * @remark The merged commit is always considered as more recent than the
-     *         ones already merged.
      */
-    public function merge(\SimpleXMLElement $mesa, \Mesamatrix\Git\Commit $commit) {
+    public function loadXml(\SimpleXMLElement $mesa) {
         foreach ($mesa->apis->api as $api) {
-            $this->mergeApi($api, $commit);
+            $this->loadXmlApi($api);
         }
     }
 
-    private function mergeApi(\SimpleXMLElement $api, \Mesamatrix\Git\Commit $commit) {
+    private function loadXmlApi(\SimpleXMLElement $api) {
         $xmlSections = $api->versions->version;
 
-        // Remove old sections.
-        $numXmlSections = count($xmlSections);
-        foreach ($this->getGlVersions() as $glSection) {
-            $glName = $glSection->getGlName();
-            if ($glName !== (string) $api['name'])
-                break;
-
-            // Find section in the XML.
-            $glVersion = $glSection->getGlVersion();
-            $i = 0;
-            while ($i < $numXmlSections) {
-                $xmlSection = $xmlSections[$i];
-                if ($glVersion === (string) $xmlSection['version']) {
-                    break;
-                }
-
-                ++$i;
-            }
-
-            if ($i === $numXmlSections) {
-                // Section not found in XML, remove it.
-                \Mesamatrix::$logger->debug('Remove GL version: '.$glName.' '.$glVersion);
-                $this->removeGlVersion($glSection);
-            }
-        }
-
-        // Add and merge new sections.
+        // Add new sections.
         foreach ($xmlSections as $xmlSection) {
             $glName = (string) $xmlSection['name'];
             $glVersion = (string) $xmlSection['version'];
 
-            $glSection = $this->getGlVersionByName($glName, $glVersion);
-            if (!$glSection) {
-                $xmlShaderVersion = $xmlSection->{'shader-version'};
-                $shaderName = (string) $xmlShaderVersion['name'];
-                $shaderVersion = (string) $xmlShaderVersion['version'];
+            $xmlShaderVersion = $xmlSection->{'shader-version'};
+            $shaderName = (string) $xmlShaderVersion['name'];
+            $shaderVersion = (string) $xmlShaderVersion['version'];
 
-                $glSection = new OglVersion($glName, $glVersion, $shaderName, $shaderVersion, $this->getHints());
-                $this->addGlVersion($glSection);
-            }
+            $glSection = new OglVersion($glName, $glVersion, $shaderName, $shaderVersion, $this->getHints());
+            $this->addGlVersion($glSection);
 
-            $glSection->merge($xmlSection, $commit);
+            $glSection->loadXml($xmlSection);
         }
     }
 
+    /**
+     * Get the GL versions.
+     *
+     * @return \Mesamatrix\Parser\OglVersion[] The GL versions array.
+     */
     public function getGlVersions() {
         return $this->glVersions;
     }
 
+    /**
+     * Get the GL version based on its name.
+     *
+     * @param string $name The GL name.
+     * @param string $version The GL version.
+     *
+     * @return \Mesamatrix\Parser\OglVersion The GL version is found; NULL otherwise.
+     */
     public function getGlVersionByName($name, $version) {
         foreach ($this->glVersions as $glVersion) {
             if ($glVersion->getGlName() === $name &&
@@ -162,6 +136,11 @@ class OglMatrix
         return null;
     }
 
+    /**
+     * Get the hints.
+     *
+     * @return \Mesamatrix\Parser\Hints The hints.
+     */
     public function getHints() {
         return $this->hints;
     }

--- a/lib/Parser/OglSupportedDriver.php
+++ b/lib/Parser/OglSupportedDriver.php
@@ -46,6 +46,13 @@ class OglSupportedDriver
     public function getHintIdx() {
         return $this->hintIdx;
     }
+    public function getHint() {
+        if ($this->hintIdx === -1) {
+            return null;
+        }
+
+        return $this->hints->allHints[$this->hintIdx];
+    }
 
     // modified at
     public function setModifiedAt($commit) {
@@ -53,17 +60,6 @@ class OglSupportedDriver
     }
     public function getModifiedAt() {
         return $this->modifiedAt;
-    }
-
-    // merge
-    public function incorporate(OglSupportedDriver $other, Commit $commit) {
-        if ($this->name !== $other->name) {
-            \Mesamatrix::$logger->error("Merging supported drivers with different names ('$this->name' != '$other->name')");
-        }
-        if ($this->hintIdx !== $other->hintIdx) {
-            $this->hintIdx = $other->hintIdx;
-            $this->setModifiedAt($commit);
-        }
     }
 
     private $name;


### PR DESCRIPTION
Before, commits were merged from the oldest to the most recent. This led
to some issues like some false-negatives on the supported drivers.

Now, the latest commit is parsed and then the other commits are compared
to this one (from the most recent to the oldest). If a change is
detected in the extension or its supported drivers, they are tagged with
the commit that induced the change.