### PR TITLE
Define return values for the commands

### DIFF
--- a/lib/Console/Command/Fetch.php
+++ b/lib/Console/Command/Fetch.php
@@ -21,22 +21,25 @@
 
 namespace Mesamatrix\Console\Command;
 
+use \Symfony\Component\Console\Command\Command;
 use \Symfony\Component\Console\Input\InputInterface;
 use \Symfony\Component\Console\Output\OutputInterface;
 
-class Fetch extends \Symfony\Component\Console\Command\Command
+class Fetch extends Command
 {
-    protected function configure()
+    protected function configure(): void
     {
         $this->setName('fetch')
              ->setDescription('Perform update of Mesa git repository')
         ;
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $branch = \Mesamatrix::$config->getValue("git", "branch");
         $fetch = new \Mesamatrix\Git\Process(array('fetch', '-f', 'origin', "$branch:$branch"));
         $this->getHelper('process')->mustRun($output, $fetch);
+
+        return Command::SUCCESS;
     }
 }

--- a/lib/Console/Command/Parse.php
+++ b/lib/Console/Command/Parse.php
@@ -21,6 +21,7 @@
 
 namespace Mesamatrix\Console\Command;
 
+use \Symfony\Component\Console\Command\Command;
 use \Symfony\Component\Console\Input\InputInterface;
 use \Symfony\Component\Console\Input\InputOption;
 use \Symfony\Component\Console\Output\OutputInterface;
@@ -38,13 +39,14 @@ use \Mesamatrix\Parser\Hints;
  * It reads all the commits of the file features.txt and transform it to an XML
  * file. The entry point for this class is the `execute()` method.
  */
-class Parse extends \Symfony\Component\Console\Command\Command
+class Parse extends Command
 {
     protected $output;
     protected $statuses;
     protected $urlCache;
 
-    protected function configure() {
+    protected function configure(): void
+    {
         $this->setName('parse')
              ->setDescription('Parse data and generate XML')
              ->addOption('force', '-f',
@@ -55,7 +57,8 @@ class Parse extends \Symfony\Component\Console\Command\Command
                          'Regenerate the XML based on the already parsed commits');
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output) {
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
         $force = $input->getOption('force');
         $regenXml = $input->getOption('regenerate-xml');
 
@@ -80,7 +83,7 @@ class Parse extends \Symfony\Component\Console\Command\Command
 
         if (empty($commits)) {
             // No commit found, exit.
-            return 1;
+            return Command::FAILURE;
         }
 
         $numCommits = count($commits);
@@ -112,7 +115,7 @@ class Parse extends \Symfony\Component\Console\Command\Command
         if ($lastCommitFetched === $lastCommitParsed) {
             \Mesamatrix::$logger->info("No new commit, no need to parse.");
             if (!$regenXml)
-                return 0;
+                return Command::SUCCESS;
         }
 
         // Ensure existence of the commits directory.
@@ -121,7 +124,7 @@ class Parse extends \Symfony\Component\Console\Command\Command
         if (!is_dir($commitsDir)) {
             if (!mkdir($commitsDir)) {
                 \Mesamatrix::$logger->critical('Couldn\'t create directory `'.$commitsDir.'`.');
-                return 1;
+                return Command::FAILURE;
             }
         }
 
@@ -159,6 +162,8 @@ class Parse extends \Symfony\Component\Console\Command\Command
             fwrite($h, $lastCommitFetched);
             fclose($h);
         }
+
+        return Command::SUCCESS;
     }
 
     /**

--- a/lib/Console/Command/Setup.php
+++ b/lib/Console/Command/Setup.php
@@ -21,19 +21,20 @@
 
 namespace Mesamatrix\Console\Command;
 
+use \Symfony\Component\Console\Command\Command;
 use \Symfony\Component\Console\Input\InputInterface;
 use \Symfony\Component\Console\Output\OutputInterface;
 
-class Setup extends \Symfony\Component\Console\Command\Command
+class Setup extends Command
 {
-    protected function configure()
+    protected function configure(): void
     {
         $this->setName('setup')
-             ->setDescription('Initialise Mesamatrix')
+             ->setDescription('Initialize Mesamatrix')
         ;
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $dateLastYear = date("Y-m-d", time() - 31536000);
         $branch = \Mesamatrix::$config->getValue("git", "branch");
@@ -43,5 +44,7 @@ class Setup extends \Symfony\Component\Console\Command\Command
         ));
         $git->setTimeout(null);
         $this->getHelper('process')->mustRun($output, $git);
+
+        return Command::SUCCESS;
     }
 }

--- a/lib/base.php
+++ b/lib/base.php
@@ -18,6 +18,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+//declare(strict_types=1);
+
 use Monolog\Logger;
 use Monolog\ErrorHandler;
 use Monolog\Handler\ErrorLogHandler;
@@ -72,8 +74,8 @@ class Mesamatrix
         }
 
         if ($logLevel < Logger::INFO) {
-            ini_set('error_reporting', E_ALL);
-            ini_set('display_errors', 1);
+            ini_set('display_errors', '1');
+            error_reporting(E_ALL);
         }
 
         // Check extensions dependencies
@@ -82,10 +84,10 @@ class Mesamatrix
             exit(1);
         }
 
-        // initialise request
+        // Initialize request
         self::$request = HTTPRequest::createFromGlobals();
 
-        self::$logger->debug('Base initialisation complete');
+        self::$logger->debug('Base initialization complete');
 
         self::$logger->debug('Log level: '.self::$logger->getLevelName($logLevel));
         self::$logger->debug('PHP error_reporting: 0x'.dechex(ini_get('error_reporting')));
@@ -98,4 +100,3 @@ class Mesamatrix
 }
 
 \Mesamatrix::init();
-

--- a/mesamatrixctl
+++ b/mesamatrixctl
@@ -20,7 +20,8 @@
  */
 
 require_once "lib/base.php";
-ini_set('display_errors', 1);
+
+ini_set('display_errors', '1');
 
 $application = new \Mesamatrix\Console\Application();
 $application->run();


### PR DESCRIPTION
This bug arrived during one of the symfony package upgrade and since no values were returned in the execute commands, the default value returned is `null` (as defined per PHP standard), which is translated to 255. So when the cron job was running `./mesamatrix fetch && ./mesamatrix parse`, it was blocked at the fetching part.

I changed the code to return proper exit values, and also took benefit of the PHP 7.4 min restriction to define the return type (e.g. `function f(): int`)