### PR TITLE
Add PHP CodeSniffer

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ copy this contents:
 ```php
 <?php
 
-use \Monolog\Logger as Log;
+use Monolog\Logger as Log;
 
 $CONFIG = array(
     "info" => array(

--- a/composer.json
+++ b/composer.json
@@ -28,6 +28,10 @@
         "suin/php-rss-writer": "*"
     },
 
+    "require-dev": {
+        "squizlabs/php_codesniffer": "*"
+    },
+
     "autoload": {
         "psr-4": {
             "Mesamatrix\\": "lib/"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a9eabd34a16ad34e69f0219e2799fcfd",
+    "content-hash": "d12e3b4f21db6ea1e03e9320de183d5b",
     "packages": [
         {
             "name": "monolog/monolog",
@@ -1918,7 +1918,64 @@
             "time": "2021-10-26T09:30:15+00:00"
         }
     ],
-    "packages-dev": [],
+    "packages-dev": [
+        {
+            "name": "squizlabs/php_codesniffer",
+            "version": "3.6.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
+                "reference": "f268ca40d54617c6e06757f83f699775c9b3ff2e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/f268ca40d54617c6e06757f83f699775c9b3ff2e",
+                "reference": "f268ca40d54617c6e06757f83f699775c9b3ff2e",
+                "shasum": ""
+            },
+            "require": {
+                "ext-simplexml": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
+                "php": ">=5.4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0"
+            },
+            "bin": [
+                "bin/phpcs",
+                "bin/phpcbf"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.x-dev"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Greg Sherwood",
+                    "role": "lead"
+                }
+            ],
+            "description": "PHP_CodeSniffer tokenizes PHP, JavaScript and CSS files and detects violations of a defined set of coding standards.",
+            "homepage": "https://github.com/squizlabs/PHP_CodeSniffer",
+            "keywords": [
+                "phpcs",
+                "standards"
+            ],
+            "support": {
+                "issues": "https://github.com/squizlabs/PHP_CodeSniffer/issues",
+                "source": "https://github.com/squizlabs/PHP_CodeSniffer",
+                "wiki": "https://github.com/squizlabs/PHP_CodeSniffer/wiki"
+            },
+            "time": "2021-10-11T04:00:11+00:00"
+        }
+    ],
     "aliases": [],
     "minimum-stability": "stable",
     "stability-flags": [],

--- a/config/config.default.php
+++ b/config/config.default.php
@@ -1,9 +1,9 @@
 <?php
 
-// Default configuration for MesaMatrix
-// Copy to config/config.php for use
+// Default configuration for Mesamatrix.
+// Values can be overwritten in a user defined config/config.php file.
 
-use \Monolog\Logger as Log;
+use Monolog\Logger as Log;
 /* available log levels:
  * Log::EMERGENCY
  * Log::ALERT

--- a/http/rss.php
+++ b/http/rss.php
@@ -21,16 +21,17 @@
 
 require_once "../lib/base.php";
 
-use \Symfony\Component\HttpFoundation\Response as HTTPResponse;
-use \Suin\RSSWriter\Feed as RSSFeed;
-use \Suin\RSSWriter\Channel as RSSChannel;
-use \Suin\RSSWriter\Item as RSSItem;
+use Mesamatrix\Mesamatrix;
+use Symfony\Component\HttpFoundation\Response as HTTPResponse;
+use Suin\RSSWriter\Feed as RSSFeed;
+use Suin\RSSWriter\Channel as RSSChannel;
+use Suin\RSSWriter\Item as RSSItem;
 
 function rssGenerationNeeded(string $featuresXmlFilepath, string $rssFilepath)
 {
     if (file_exists($featuresXmlFilepath) && file_exists($rssFilepath))
     {
-        $lastCommitFilepath = \Mesamatrix::path(\Mesamatrix::$config->getValue('info', 'private_dir', 'private'))
+        $lastCommitFilepath = Mesamatrix::path(Mesamatrix::$config->getValue('info', 'private_dir', 'private'))
             . '/last_commit_parsed';
         if (file_exists($lastCommitFilepath))
         {
@@ -46,7 +47,7 @@ function generateRss(string $featuresXmlFilepath)
 {
     $xml = simplexml_load_file($featuresXmlFilepath);
     if (!$xml) {
-        \Mesamatrix::$logger->critical("Can't read ".$featuresXmlFilepath);
+        Mesamatrix::$logger->critical("Can't read ".$featuresXmlFilepath);
         exit();
     }
 
@@ -60,17 +61,17 @@ function generateRss(string $featuresXmlFilepath)
     // prepare RSS
     $rss = new RSSFeed();
 
-    $baseUrl = \Mesamatrix::$request->getSchemeAndHttpHost()
-        . \Mesamatrix::$request->getBasePath();
+    $baseUrl = Mesamatrix::$request->getSchemeAndHttpHost()
+        . Mesamatrix::$request->getBasePath();
 
     $channel = new RSSChannel();
     $channel
-        ->title(\Mesamatrix::$config->getValue("info", "title"))
-        ->description(\Mesamatrix::$config->getValue("info", "description"))
+        ->title(Mesamatrix::$config->getValue("info", "title"))
+        ->description(Mesamatrix::$config->getValue("info", "description"))
         ->url($baseUrl)
         ->appendTo($rss);
 
-    //$commitWeb = \Mesamatrix::$config->getValue("git", "mesa_commit_url");
+    //$commitWeb = Mesamatrix::$config->getValue("git", "mesa_commit_url");
 
     foreach ($xml->commits->commit as $commit) {
         if ((int)$commit["timestamp"] < $minTime)
@@ -97,8 +98,8 @@ function generateRss(string $featuresXmlFilepath)
     return $rss->render();
 }
 
-$featuresXmlFilepath = \Mesamatrix::path(\Mesamatrix::$config->getValue("info", "xml_file"));
-$rssFilepath = \Mesamatrix::path(\Mesamatrix::$config->getValue('info', 'private_dir', 'private'))
+$featuresXmlFilepath = Mesamatrix::path(Mesamatrix::$config->getValue("info", "xml_file"));
+$rssFilepath = Mesamatrix::path(Mesamatrix::$config->getValue('info', 'private_dir', 'private'))
     . '/rss.xml';
 
 $mustGenerateRss = rssGenerationNeeded($featuresXmlFilepath, $rssFilepath);
@@ -116,7 +117,7 @@ if ($mustGenerateRss)
         fclose($h);
     }
 
-    \Mesamatrix::$logger->info('RSS file generated.');
+    Mesamatrix::$logger->info('RSS file generated.');
 }
 else
 {
@@ -131,5 +132,5 @@ $response = new HTTPResponse(
     ['Content-Type' => 'text/xml']
 );
 
-$response->prepare(\Mesamatrix::$request);
+$response->prepare(Mesamatrix::$request);
 $response->send();

--- a/lib/Config.php
+++ b/lib/Config.php
@@ -45,17 +45,17 @@ class Config
         }
         $logMsg = 'Unable to find config value for '.$section.'.'.$key;
         if (is_null($default)) {
-            \Mesamatrix::$logger->error($logMsg);
+            Mesamatrix::$logger->error($logMsg);
         }
         else {
-            \Mesamatrix::$logger->info($logMsg.', using default '.$default);
+            Mesamatrix::$logger->info($logMsg.', using default '.$default);
         }
         return $default;
     }
 
     public function readData($configFile) {
         if (file_exists($configFile)) {
-            \Mesamatrix::$logger->info('Loading configuration file '.$configFile);
+            Mesamatrix::$logger->info('Loading configuration file '.$configFile);
             @include $configFile;
             if (isset($CONFIG) && is_array($CONFIG)) {
                 foreach ($CONFIG as $section => $sectionConfig) {

--- a/lib/Console/Application.php
+++ b/lib/Console/Application.php
@@ -20,17 +20,18 @@
 
 namespace Mesamatrix\Console;
 
-use \Symfony\Component\Console\Input\InputInterface;
-use \Symfony\Component\Console\Output\OutputInterface;
-use \Symfony\Component\Console\ConsoleEvents;
-use \Symfony\Component\EventDispatcher\EventDispatcher;
-use \Symfony\Component\Console\Event\ConsoleCommandEvent;
+use Mesamatrix\Mesamatrix;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\ConsoleEvents;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\Console\Event\ConsoleCommandEvent;
 
 class Application extends \Symfony\Component\Console\Application
 {
     public function __construct()
     {
-        parent::__construct('Mesamatrix CLI', \Mesamatrix::$config->getValue('info', 'version'));
+        parent::__construct('Mesamatrix CLI', Mesamatrix::$config->getValue('info', 'version'));
 
         $dispatcher = new EventDispatcher();
 
@@ -40,12 +41,12 @@ class Application extends \Symfony\Component\Console\Application
             {
                 $logger = new \Monolog\Logger(
                     'cli.'.$e->getCommand()->getName(),
-                    \Mesamatrix::$logger->getHandlers()
+                    Mesamatrix::$logger->getHandlers()
                 );
                 $logger->pushHandler(
                     new \Symfony\Bridge\Monolog\Handler\ConsoleHandler($e->getOutput())
                 );
-                \Mesamatrix::$logger = $logger;
+                Mesamatrix::$logger = $logger;
             }
         );
 

--- a/lib/Console/Command/Fetch.php
+++ b/lib/Console/Command/Fetch.php
@@ -21,9 +21,11 @@
 
 namespace Mesamatrix\Console\Command;
 
-use \Symfony\Component\Console\Command\Command;
-use \Symfony\Component\Console\Input\InputInterface;
-use \Symfony\Component\Console\Output\OutputInterface;
+use Mesamatrix\Git\Process;
+use Mesamatrix\Mesamatrix;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
 
 class Fetch extends Command
 {
@@ -36,8 +38,8 @@ class Fetch extends Command
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $branch = \Mesamatrix::$config->getValue("git", "branch");
-        $fetch = new \Mesamatrix\Git\Process(array('fetch', '-f', 'origin', "$branch:$branch"));
+        $branch = Mesamatrix::$config->getValue("git", "branch");
+        $fetch = new Process(array('fetch', '-f', 'origin', "$branch:$branch"));
         $this->getHelper('process')->mustRun($output, $fetch);
 
         return Command::SUCCESS;

--- a/lib/Console/Command/Setup.php
+++ b/lib/Console/Command/Setup.php
@@ -21,9 +21,11 @@
 
 namespace Mesamatrix\Console\Command;
 
-use \Symfony\Component\Console\Command\Command;
-use \Symfony\Component\Console\Input\InputInterface;
-use \Symfony\Component\Console\Output\OutputInterface;
+use Mesamatrix\Mesamatrix;
+use Mesamatrix\Git\Process;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
 
 class Setup extends Command
 {
@@ -37,10 +39,10 @@ class Setup extends Command
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $dateLastYear = date("Y-m-d", time() - 31536000);
-        $branch = \Mesamatrix::$config->getValue("git", "branch");
-        $git = new \Mesamatrix\Git\Process(array(
+        $branch = Mesamatrix::$config->getValue("git", "branch");
+        $git = new Process(array(
             'clone', '--bare', "--shallow-since=$dateLastYear", "--branch=$branch",
-            \Mesamatrix::$config->getValue('git', 'mesa_url'), '@gitDir@'
+            Mesamatrix::$config->getValue('git', 'mesa_url'), '@gitDir@'
         ));
         $git->setTimeout(null);
         $this->getHelper('process')->mustRun($output, $git);

--- a/lib/Controller/AboutController.php
+++ b/lib/Controller/AboutController.php
@@ -20,6 +20,8 @@
 
 namespace Mesamatrix\Controller;
 
+use Mesamatrix\Mesamatrix;
+
 class AboutController extends BaseController
 {
     public function __construct() {
@@ -32,21 +34,21 @@ class AboutController extends BaseController
     }
 
     protected function writeHtmlPage() {
-        $mesaWeb = \Mesamatrix::$config->getValue('git', 'mesa_web');
-        $mesaBranch = \Mesamatrix::$config->getValue('git', 'branch');
+        $mesaWeb = Mesamatrix::$config->getValue('git', 'mesa_web');
+        $mesaBranch = Mesamatrix::$config->getValue('git', 'branch');
 ?>
             <h1>About Mesamatrix</h1>
             <h2>How it works</h2>
             <p>The Mesa <a href="<?= $mesaWeb ?>" target="_blank">git repo</a> is frequently fetched and, if there is a new commit for the <a href="<?= "$mesaWeb/blob/$mesaBranch/docs/features.txt" ?>" target="_blank">features.txt</a> text file, a <abbr title="PHP: Hypertext Preprocessor">PHP</abbr> script will parse it and format it into <abbr title="Extensible Markup Language">XML</abbr>. Then another PHP script displays the data into the <abbr title="Hypertext Markup Language">HTML</abbr> you can see here.</p>
             <h2>Source code</h2>
-            <p>The code is free and licenced under <abbr title="Affero General Public License">AGPL</abbr> v3. If you want to report a bug, participate to the project or simply browse the code: <a href="<?= \Mesamatrix::$config->getValue("info", "project_url") ?>"><?= \Mesamatrix::$config->getValue("info", "project_url") ?></a></p>
+            <p>The code is free and licenced under <abbr title="Affero General Public License">AGPL</abbr> v3. If you want to report a bug, participate to the project or simply browse the code: <a href="<?= Mesamatrix::$config->getValue("info", "project_url") ?>"><?= Mesamatrix::$config->getValue("info", "project_url") ?></a></p>
             <p><a href="https://www.gnu.org/licenses/agpl.html"><img src="https://www.gnu.org/graphics/agplv3-155x51.png" alt="Logo AGPLv3" height="51" /></a></p>
             <h2>Contact</h2>
             <p>Feel free to join the Matrix room <a href="https://matrix.to/#/#mesamatrix:matrix.org" target="_blank">#mesamatrix:matrix.org</a> and discuss.</p>
             <h3>Authors</h3>
             <ul>
 <?php
-foreach (\Mesamatrix::$config->getValue("info", "authors") as $k => $v):
+foreach (Mesamatrix::$config->getValue("info", "authors") as $k => $v):
     if (is_string($k)):
 ?>
                 <li><a href="<?= $v ?>"><?= $k ?></a></li>
@@ -71,4 +73,4 @@ endforeach;
             </ul>
 <?php
     }
-};
+}

--- a/lib/Controller/BaseController.php
+++ b/lib/Controller/BaseController.php
@@ -20,6 +20,8 @@
 
 namespace Mesamatrix\Controller;
 
+use Mesamatrix\Mesamatrix;
+
 abstract class BaseController
 {
     public $pages = array(
@@ -32,7 +34,7 @@ abstract class BaseController
     private $jsScripts = [];
 
     public function __construct() {
-        $this->addCssScript('css/style.css?v='.(\Mesamatrix::$config->getValue("info", "version")));
+        $this->addCssScript('css/style.css?v='.(Mesamatrix::$config->getValue("info", "version")));
 
         $this->addJsScript('js/jquery-1.11.3.min.js');
     }
@@ -93,11 +95,11 @@ abstract class BaseController
 <html lang="en">
     <head>
         <meta charset="utf-8"/>
-        <meta name="description" content="<?= \Mesamatrix::$config->getValue("info", "description") ?>"/>
+        <meta name="description" content="<?= Mesamatrix::$config->getValue("info", "description") ?>"/>
 
-        <title><?= \Mesamatrix::$config->getValue("info", "title") ?></title>
+        <title><?= Mesamatrix::$config->getValue("info", "title") ?></title>
 
-        <meta property="og:title" content="Mesamatrix: <?= \Mesamatrix::$config->getValue("info", "title") ?>" />
+        <meta property="og:title" content="Mesamatrix: <?= Mesamatrix::$config->getValue("info", "title") ?>" />
         <meta property="og:type" content="website" />
         <meta property="og:image" content="//mesamatrix.net/images/mesamatrix-logo.png" />
 
@@ -157,7 +159,7 @@ abstract class BaseController
 ?>
         </main>
         <footer>
-            <a id="github-ribbon" href="<?= \Mesamatrix::$config->getValue("info", "project_url") ?>"><img src="https://camo.githubusercontent.com/652c5b9acfaddf3a9c326fa6bde407b87f7be0f4/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f6f72616e67655f6666373630302e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_orange_ff7600.png" /></a>
+            <a id="github-ribbon" href="<?= Mesamatrix::$config->getValue("info", "project_url") ?>"><img src="https://camo.githubusercontent.com/652c5b9acfaddf3a9c326fa6bde407b87f7be0f4/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f6f72616e67655f6666373630302e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_orange_ff7600.png" /></a>
             <div class="theme-switch-wrapper">
                 <label class="theme-switch" for="checkbox">
                     <input type="checkbox" id="checkbox" />
@@ -169,4 +171,4 @@ abstract class BaseController
 </html>
 <?php
     }
-};
+}

--- a/lib/Controller/DriversController.php
+++ b/lib/Controller/DriversController.php
@@ -48,4 +48,4 @@ class DriversController extends BaseController
             </p>
 <?php
     }
-};
+}

--- a/lib/Controller/HomeController.php
+++ b/lib/Controller/HomeController.php
@@ -20,7 +20,9 @@
 
 namespace Mesamatrix\Controller;
 
-use \Mesamatrix\Parser\Constants;
+use Mesamatrix\Mesamatrix;
+use Mesamatrix\Parser\Constants;
+use Mesamatrix\Leaderboard\Leaderboard;
 
 class HomeController extends BaseController
 {
@@ -57,10 +59,10 @@ class HomeController extends BaseController
     }
 
     private function loadMesamatrixXml() {
-        $featuresXmlFilepath = \Mesamatrix::path(\Mesamatrix::$config->getValue('info', 'xml_file'));
+        $featuresXmlFilepath = Mesamatrix::path(Mesamatrix::$config->getValue('info', 'xml_file'));
         $xml = simplexml_load_file($featuresXmlFilepath);
         if (!$xml) {
-            \Mesamatrix::$logger->critical('Can\'t read '.$featuresXmlFilepath);
+            Mesamatrix::$logger->critical('Can\'t read '.$featuresXmlFilepath);
             exit();
         }
 
@@ -70,12 +72,12 @@ class HomeController extends BaseController
     private function createCommitsModel(\SimpleXMLElement $xml) {
         $this->commits = array();
 
-        $numCommits = \Mesamatrix::$config->getValue('info', 'commitlog_length', 10);
+        $numCommits = Mesamatrix::$config->getValue('info', 'commitlog_length', 10);
         $numCommits = min($numCommits, $xml->commits->commit->count());
         for ($i = 0; $i < $numCommits; ++$i) {
             $xmlCommit = $xml->commits->commit[$i];
             $this->commits[] = array(
-                'url' => \Mesamatrix::$config->getValue('git', 'mesa_commit_url').$xmlCommit['hash'],
+                'url' => Mesamatrix::$config->getValue('git', 'mesa_commit_url').$xmlCommit['hash'],
                 'timestamp' => (int) $xmlCommit['timestamp'],
                 'subject' => $xmlCommit['subject']
             );
@@ -83,14 +85,14 @@ class HomeController extends BaseController
     }
 
     private function createLeaderboard(\SimpleXMLElement $xml, array $apis) {
-        $leaderboard = new \Mesamatrix\Leaderboard\Leaderboard();
+        $leaderboard = new Leaderboard();
         $leaderboard->load($xml, $apis);
         return $leaderboard;
     }
 
     protected function writeHtmlPage() {
-        $mesaWeb = \Mesamatrix::$config->getValue('git', 'mesa_web');
-        $mesaBranch = \Mesamatrix::$config->getValue('git', 'branch');
+        $mesaWeb = Mesamatrix::$config->getValue('git', 'mesa_web');
+        $mesaBranch = Mesamatrix::$config->getValue('git', 'branch');
 ?>
     <p>
         This page is a graphical representation of the text file <a href="<?= "$mesaWeb/blob/$mesaBranch/docs/features.txt" ?>" target="_blank">docs/features.txt</a> from the Mesa repository.
@@ -99,7 +101,7 @@ class HomeController extends BaseController
         Although this text file is updated by the Mesa developers themselves, it might not contain an exhaustive list of all the drivers features and subtleties. So, for more information, it is advised to look at the <a href="<?= $mesaWeb ?>" target="_blank">source code</a>, or ask the developers on their <a href="https://mesa3d.org/lists.html" target="_blank">mailing-list</a>.
     </p>
     <p>
-        Feel free to open an issue or create a PR on <a href="<?= \Mesamatrix::$config->getValue('info', 'project_url') ?>" target="_blank">GitHub</a>, or join the Matrix room <a href="https://matrix.to/#/%23mesamatrix:matrix.org" target="_blank">#mesamatrix:matrix.org</a>.
+        Feel free to open an issue or create a PR on <a href="<?= Mesamatrix::$config->getValue('info', 'project_url') ?>" target="_blank">GitHub</a>, or join the Matrix room <a href="https://matrix.to/#/%23mesamatrix:matrix.org" target="_blank">#mesamatrix:matrix.org</a>.
     </p>
 
     <h1>Last commits</h1>
@@ -136,4 +138,4 @@ class HomeController extends BaseController
             $apiController->writeMatrix();
         }
     }
-};
+}

--- a/lib/Git/Process.php
+++ b/lib/Git/Process.php
@@ -21,13 +21,15 @@
 
 namespace Mesamatrix\Git;
 
+use Mesamatrix\Mesamatrix;
+
 class Process extends \Symfony\Component\Process\Process
 {
     public function __construct(array $arguments = array())
     {
         // Replace '@gitDir@' by Mesa Git directory.
-        $gitDir = \Mesamatrix::path(\Mesamatrix::$config->getValue("info", "private_dir"))."/";
-        $gitDir .= \Mesamatrix::$config->getValue("git", "mesa_dir", "mesa.git");
+        $gitDir = Mesamatrix::path(Mesamatrix::$config->getValue("info", "private_dir"))."/";
+        $gitDir .= Mesamatrix::$config->getValue("git", "mesa_dir", "mesa.git");
         foreach ($arguments as &$arg) {
             $arg = str_replace('@gitDir@', $gitDir, $arg);
         }
@@ -35,7 +37,7 @@ class Process extends \Symfony\Component\Process\Process
         // Ensure existence of the Mesa Git directory.
         if (!is_dir($gitDir)) {
             if (!mkdir($gitDir)) {
-                \Mesamatrix::$logger->critical('Couldn\'t create directory `'.$gitDir.'`.');
+                Mesamatrix::$logger->critical('Couldn\'t create directory `'.$gitDir.'`.');
                 return 1;
             }
         }

--- a/lib/Hints.php
+++ b/lib/Hints.php
@@ -60,5 +60,4 @@ class Hints
     }
 
     private $list;
-};
-
+}

--- a/lib/Leaderboard/Leaderboard.php
+++ b/lib/Leaderboard/Leaderboard.php
@@ -20,7 +20,7 @@
 
 namespace Mesamatrix\Leaderboard;
 
-use \Mesamatrix\Parser\Constants;
+use Mesamatrix\Parser\Constants;
 
 class Leaderboard {
     /**

--- a/lib/Mesamatrix.php
+++ b/lib/Mesamatrix.php
@@ -1,0 +1,96 @@
+<?php
+/*
+ * This file is part of mesamatrix.
+ *
+ * Copyright (C) 2021 Romain "Creak" Failliot.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace Mesamatrix;
+
+use Monolog\Logger;
+use Monolog\ErrorHandler;
+use Monolog\Handler\ErrorLogHandler;
+use Monolog\Handler\StreamHandler;
+use Symfony\Component\HttpFoundation\Request as HTTPRequest;
+
+class Mesamatrix
+{
+    public static $serverRoot; // Path to root of installation
+    public static $configDir; // Path to configuration directory
+    public static $config; // Config object
+    public static $logger; // Logger
+    public static $request; // HTTP request object
+
+    public static function init() {
+        date_default_timezone_set('UTC');
+
+        self::$serverRoot = dirname(__DIR__);
+
+        self::$logger = new Logger('logger');
+        self::$logger->pushHandler(new ErrorLogHandler(
+            ErrorLogHandler::OPERATING_SYSTEM,
+            Logger::NOTICE
+        ));
+        ErrorHandler::register(self::$logger);
+
+        self::$configDir = self::path('config');
+        self::$config = new Config(self::$configDir);
+
+        // attempt to create the private dir
+        $privateDir = self::path(self::$config->getValue('info', 'private_dir'));
+        if (!is_dir($privateDir)) {
+            mkdir($privateDir);
+        }
+
+        // register the log file
+        $logLevel = self::$config->getValue('info', 'log_level', Logger::WARNING);
+        $logPath = $privateDir.'/mesamatrix.log';
+        if (!file_exists($logPath) && is_dir($privateDir)) {
+            touch($logPath);
+        }
+        if (is_writable($logPath)) {
+            self::$logger->popHandler();
+            self::$logger->pushHandler(new StreamHandler($logPath, $logLevel));
+        }
+        else {
+            self::$logger->error('Error log '.$logPath.' is not writable!');
+        }
+
+        if ($logLevel < Logger::INFO) {
+            ini_set('display_errors', '1');
+            error_reporting(E_ALL);
+        }
+
+        // Check extensions dependencies
+        if (!extension_loaded('xml')) {
+            self::$logger->error('Could not find XML extension');
+            exit(1);
+        }
+
+        // Initialize request
+        self::$request = HTTPRequest::createFromGlobals();
+
+        self::$logger->debug('Base initialization complete');
+
+        self::$logger->debug('Log level: '.self::$logger->getLevelName($logLevel));
+        self::$logger->debug('PHP error_reporting: 0x'.dechex(ini_get('error_reporting')));
+        self::$logger->debug('PHP display_errors: '.ini_get('display_errors'));
+    }
+
+    public static function path($path) {
+        return self::$serverRoot.'/'.$path;
+    }
+}

--- a/lib/Parser/ApiVersion.php
+++ b/lib/Parser/ApiVersion.php
@@ -20,6 +20,8 @@
 
 namespace Mesamatrix\Parser;
 
+use Mesamatrix\Mesamatrix;
+
 class ApiVersion
 {
     public function __construct(
@@ -132,7 +134,7 @@ class ApiVersion
     /**
      * Parse all the extensions in the version and solve them.
      *
-     * @param \Mesamatrix\Parser\Matrix $matrix The entire matrix.
+     * @param Matrix $matrix The entire matrix.
      */
     public function solveExtensionDependencies($matrix) {
         foreach ($this->getExtensions() as $ext) {
@@ -157,7 +159,7 @@ class ApiVersion
                 // Get driver name and verify it's valid.
                 $driverName = (string) $xmlSupportedDriver['name'];
                 if (!in_array($driverName, $apiDrivers)) {
-                    \Mesamatrix::$logger->error('Unrecognized driver: '.$driverName);
+                    Mesamatrix::$logger->error('Unrecognized driver: '.$driverName);
                     continue;
                 }
 
@@ -232,4 +234,4 @@ class ApiVersion
     private ?string $glslVersion;
     private Hints $hints;
     private array $extensions;
-};
+}

--- a/lib/Parser/Constants.php
+++ b/lib/Parser/Constants.php
@@ -117,7 +117,7 @@ abstract class Constants
     // 2: dependency type
     // 3: dependency match index
     const RE_DEP_DRIVERS_HINTS = [
-        [ "/^all drivers that support (GL_[_[:alnum:]]+)$/i", TRUE, DependsOn::Extension, 1 ],
-        [ "/^all drivers that support GLES ?(\d+\.\d+\+?)?$/i", TRUE, DependsOn::GlesVersion, 1 ],
+        [ "/^all drivers that support (GL_[_[:alnum:]]+)$/i", TRUE, DependsOn::EXTENSION, 1 ],
+        [ "/^all drivers that support GLES ?(\d+\.\d+\+?)?$/i", TRUE, DependsOn::GLES_VERSION, 1 ],
     ];
 }

--- a/lib/Parser/DependsOn.php
+++ b/lib/Parser/DependsOn.php
@@ -24,6 +24,6 @@ namespace Mesamatrix\Parser;
  * Enum for the type of a dependency
  */
 abstract class DependsOn {
-    const Extension = 0;
-    const GlesVersion = 1;
-};
+    const EXTENSION = 0;
+    const GLES_VERSION = 1;
+}

--- a/lib/Parser/Extension.php
+++ b/lib/Parser/Extension.php
@@ -20,7 +20,8 @@
 
 namespace Mesamatrix\Parser;
 
-use \Mesamatrix\Git\Commit;
+use Mesamatrix\Git\Commit;
+use Mesamatrix\Mesamatrix;
 
 class Extension
 {
@@ -52,7 +53,7 @@ class Extension
         foreach ($supportedDrivers as $driverNameAndHint) {
             list($driverName, $driverHint) = self::splitDriverNameAndHint($driverNameAndHint, $apiDrivers);
             if ($driverName === null) {
-                \Mesamatrix::$logger->error("Unrecognized driver: '$driverNameAndHint'");
+                Mesamatrix::$logger->error("Unrecognized driver: '$driverNameAndHint'");
             }
 
             $supportedDriver = new SupportedDriver($driverName, $this->hints);
@@ -160,7 +161,7 @@ class Extension
     /**
      * Detects if the current extension depends on another one and merge the drivers.
      *
-     * @param \Mesamatrix\Parser\Matrix $matrix The entire matrix.
+     * @param Matrix $matrix The entire matrix.
      */
     public function solveExtensionDependencies($matrix) {
         $hint = $this->getHint();
@@ -171,7 +172,7 @@ class Extension
         foreach (Constants::RE_DEP_DRIVERS_HINTS as $reDepDriversHint) {
             if (preg_match($reDepDriversHint[0], $hint, $matches) === 1) {
                 switch ($reDepDriversHint[2]) {
-                    case DependsOn::Extension:
+                    case DependsOn::EXTENSION:
                     {
                         $depExt = $matrix->getExtensionBySubstr($matches[$reDepDriversHint[3]]);
                         if ($depExt !== NULL) {
@@ -182,7 +183,7 @@ class Extension
                     }
                     break;
 
-                    case DependsOn::GlesVersion:
+                    case DependsOn::GLES_VERSION:
                     {
                         $supportedDriverNames = $matrix->getDriversSupportingGlesVersion($matches[$reDepDriversHint[3]]);
                         if ($supportedDriverNames !== NULL) {
@@ -261,4 +262,4 @@ class Extension
     private array $supportedDrivers;
     private ?Commit $modifiedAt;
     private array $subextensions;
-};
+}

--- a/lib/Parser/Matrix.php
+++ b/lib/Parser/Matrix.php
@@ -37,7 +37,7 @@ class Matrix
     /**
      * Get the API versions.
      *
-     * @return \Mesamatrix\Parser\ApiVersion[] The API versions array.
+     * @return ApiVersion[] The API versions array.
      */
     public function getApiVersions() {
         return $this->apiVersions;
@@ -49,7 +49,7 @@ class Matrix
      * @param string $name The API name.
      * @param string $version The API version.
      *
-     * @return \Mesamatrix\Parser\ApiVersion The API version is found; NULL otherwise.
+     * @return ApiVersion The API version is found; NULL otherwise.
      */
     public function getApiVersionByName($name, $version) {
         foreach ($this->apiVersions as $apiVersion) {
@@ -66,7 +66,7 @@ class Matrix
      *
      * @param string $substr The substring to find.
      *
-     * @return \Mesamatrix\Parser\Extension The extension if found; NULL otherwise.
+     * @return Extension The extension if found; NULL otherwise.
      */
     public function getExtensionBySubstr($substr) {
         foreach ($this->getApiVersions() as $apiVersion) {
@@ -139,9 +139,9 @@ class Matrix
     /**
      * Get the hints.
      *
-     * @return \Mesamatrix\Parser\Hints The hints.
+     * @return Hints The hints.
      */
     public function getHints() {
         return $this->hints;
     }
-};
+}

--- a/lib/Parser/Parser.php
+++ b/lib/Parser/Parser.php
@@ -20,6 +20,8 @@
 
 namespace Mesamatrix\Parser;
 
+use Mesamatrix\Mesamatrix;
+
 class Parser
 {
     public function parse($filename) {
@@ -46,7 +48,7 @@ class Parser
      * Parse a stream of features.txt.
      *
      * @param $handle The stream handle.
-     * @return \Mesamatrix\Parser\Matrix The matrix.
+     * @return Matrix The matrix.
      */
     public function parseStream($handle) {
         $matrix = new Matrix();
@@ -166,15 +168,15 @@ class Parser
      * "All extensions". This is needed for Vulkan 1.0 (until there is a better
      * parser).
      *
-     * @param \Mesamatrix\Parser\ApiVersion $apiVersion The version section to feed during parsing.
-     * @param \Mesamatrix\Parser\Matrix $matrix The matrix to feed during parsing.
+     * @param ApiVersion $apiVersion The version section to feed during parsing.
+     * @param Matrix $matrix The matrix to feed during parsing.
      * @param $handle The file handle.
      * @param array() $allSupportedDrivers Drivers that already support all the extension in the section.
      *
      * @return The next line unparsed.
      */
-    private function parseSection(\Mesamatrix\Parser\ApiVersion $apiVersion,
-                                  \Mesamatrix\Parser\Matrix $matrix,
+    private function parseSection(ApiVersion $apiVersion,
+                                  Matrix $matrix,
                                   $handle,
                                   $allSupportedDrivers = array()) {
         $line = $this->skipEmptyLines(fgets($handle), $handle);
@@ -397,7 +399,7 @@ class Parser
                     if (preg_match($reDepDriversHint[0], $hintItem) === 1) {
                         if ($reAllDriversHint[1] === true) {
                             if ($useHint !== null) {
-                                \Mesamatrix::$logger->warning('Unhandled situation: more than one extension dependency');
+                                Mesamatrix::$logger->warning('Unhandled situation: more than one extension dependency');
                             }
 
                             $useHint = $hintItem;
@@ -424,4 +426,4 @@ class Parser
 
     const RE_ALL_DONE = "/ -+ all DONE: (.*)/i";
     const RE_NOTE = "/^(\(.+\)) (.*)$/";
-};
+}

--- a/lib/Parser/SupportedDriver.php
+++ b/lib/Parser/SupportedDriver.php
@@ -20,7 +20,7 @@
 
 namespace Mesamatrix\Parser;
 
-use \Mesamatrix\Git\Commit;
+use Mesamatrix\Git\Commit;
 
 class SupportedDriver
 {
@@ -66,4 +66,4 @@ class SupportedDriver
     private $hints;
     private $hintIdx;
     private $modifiedAt;
-};
+}

--- a/lib/Parser/UrlCache.php
+++ b/lib/Parser/UrlCache.php
@@ -20,6 +20,8 @@
 
 namespace Mesamatrix\Parser;
 
+use Mesamatrix\Mesamatrix;
+
 class UrlCache
 {
     const EXPIRATIONDELAY = 7776000; // 90 * 24 * 60 * 60 = 90 days.
@@ -38,13 +40,13 @@ class UrlCache
      * This file is encoded in JSON.
      */
     public function load() {
-        $privateDir = \Mesamatrix::$config->getValue("info", "private_dir");
-        $filepath = $privateDir.'/'.\Mesamatrix::$config->getValue("extension_links", "cache_file", "urlcache.json");
+        $privateDir = Mesamatrix::$config->getValue("info", "private_dir");
+        $filepath = $privateDir.'/'.Mesamatrix::$config->getValue("extension_links", "cache_file", "urlcache.json");
         if (file_exists($filepath) !== FALSE) {
             $urlCacheContents = file_get_contents($filepath);
             if ($urlCacheContents !== FALSE) {
                 $this->cachedUrls = json_decode($urlCacheContents, true);
-                \Mesamatrix::$logger->info("URL cache file loaded.");
+                Mesamatrix::$logger->info("URL cache file loaded.");
             }
         }
     }
@@ -55,15 +57,15 @@ class UrlCache
      * This file is encoded in JSON.
      */
     public function save() {
-        $privateDir = \Mesamatrix::$config->getValue("info", "private_dir", "private");
+        $privateDir = Mesamatrix::$config->getValue("info", "private_dir", "private");
         if (file_exists($privateDir) === FALSE)
             mkdir($privateDir, 0777, true);
-        $filepath = $privateDir.'/'.\Mesamatrix::$config->getValue("extension_links", "cache_file", "urlcache.json");
+        $filepath = $privateDir.'/'.Mesamatrix::$config->getValue("extension_links", "cache_file", "urlcache.json");
         $res = file_put_contents($filepath, json_encode($this->cachedUrls));
         if ($res !== FALSE)
-            \Mesamatrix::$logger->info("URL cache file saved: ".$filepath.".");
+            Mesamatrix::$logger->info("URL cache file saved: ".$filepath.".");
         else
-            \Mesamatrix::$logger->error("Can't save URL cache file in \"".$filepath."\".");
+            Mesamatrix::$logger->error("Can't save URL cache file in \"".$filepath."\".");
     }
 
     /**
@@ -99,7 +101,7 @@ class UrlCache
         $urlHeader = get_headers($url);
         $isValid = FALSE;
         if ($urlHeader !== FALSE) {
-            \Mesamatrix::$logger->info("Try URL \"".$url."\". Result: \"".$urlHeader[0]."\".");
+            Mesamatrix::$logger->info("Try URL \"".$url."\". Result: \"".$urlHeader[0]."\".");
             $isValid = $urlHeader[0] === "HTTP/1.1 200 OK";
         }
 

--- a/mesamatrixctl
+++ b/mesamatrixctl
@@ -23,5 +23,5 @@ require_once "lib/base.php";
 
 ini_set('display_errors', '1');
 
-$application = new \Mesamatrix\Console\Application();
-$application->run();
+$cliApp = new Mesamatrix\Console\Application();
+$cliApp->run();


### PR DESCRIPTION
* Adds dev dependency to `squizlabs/php_codesniffer`
* Fixes some errors and warnings with phpcs
* Uses `use` instead of full class paths
* Writes 'Version' instead of the API name in the last column in
  Leaderboard