### PR TITLE
style: use `pointer` cursor for summary elements

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -219,6 +219,7 @@ details {
 details > summary {
     font-size: x-large;
     font-weight: bold;
+    cursor: pointer;
 }
 
 .matrix {


### PR DESCRIPTION
Makes it clear that clicking is how you toggle them, and allows to see how far that element extends to.