### PR TITLE
fix: ./mesamatrixctl wasn't working on OSX

### DIFF
--- a/mesamatrixctl
+++ b/mesamatrixctl
@@ -1,4 +1,4 @@
-#!/usr/bin/php
+#!/usr/bin/env php
 <?php
 /*
  * This file is part of mesamatrix.


### PR DESCRIPTION
Use the more compatible shebang `#!/usr/bin/env php` instead of `#!/usr/bin/php`.

Fixes #289