### PR TITLE
fix: add asahi (Rusticl) in the vendor list

### DIFF
--- a/src/Parser/Constants.php
+++ b/src/Parser/Constants.php
@@ -124,6 +124,7 @@ abstract class Constants
     ];
     public const RUSTICL_OPENCL_ALL_DRIVERS_VENDORS = [
         'AMD'       => [ 'radeonsi' ],
+        'Apple'     => [ 'asahi' ],
         'Arm'       => [ 'panfrost' ],
         'Intel'     => [ 'iris' ],
         'Nvidia'    => [ 'nvc0' ],


### PR DESCRIPTION
This is a followup ifx for #290.

@karolherbst I don't know much about asahi, but considering that asahi is an Apple driver for OpenGL, I guess it's the same for OpenCL?