### PR TITLE
Make sure we are comparing agains the same API for the same extension

### DIFF
--- a/src/Console/Command/Parse.php
+++ b/src/Console/Command/Parse.php
@@ -412,8 +412,9 @@ class Parse extends Command
         Commit $commit
     ): void {
         foreach ($matrix->getApiVersions() as $apiVersion) {
+            $prevApiVersion = $prevMatrix->getApiVersionByName($apiVersion->getName(), $apiVersion->getVersion());
             foreach ($apiVersion->getExtensions() as $ext) {
-                $prevExt = $prevMatrix->getExtensionBySubstr($ext->getName());
+                $prevExt = $prevApiVersion !== null ? $prevApiVersion->getExtensionBySubstr($ext->getName()) : null;
 
                 $this->compareExtensionsAndSetModificationCommit($prevExt, $ext, $commit);
             }


### PR DESCRIPTION
The Clover and RustICL implementation shares similar/same extension names. This causes virtually every features implemented in RustICL to be marked as being added in the last commit since the Clover implementation most likely didn't have them implemented.

The getExtensionBySubstr method should probably be removed to avoid misuse but there's another caller in src/Parser/Extension.php that seems to be related to feature dependencies and I'm not really familiar with the logic there.