### PR TITLE
Add v3d to Rusticl

### DIFF
--- a/src/Parser/Constants.php
+++ b/src/Parser/Constants.php
@@ -122,12 +122,14 @@ abstract class Constants
         'nvc0',
         'panfrost',
         'radeonsi',
+        'v3d',
         'zink',
     ];
     public const RUSTICL_OPENCL_ALL_DRIVERS_VENDORS = [
         'AMD'         => [ 'radeonsi' ],
         'Apple'       => [ 'asahi' ],
         'Arm'         => [ 'panfrost' ],
+        'Broadcom'    => [ 'v3d' ],
         'Intel'       => [ 'iris' ],
         'Nvidia'      => [ 'nvc0' ],
         'Qualcomm'    => [ 'freedreno' ],


### PR DESCRIPTION
Initial support for rusticl was added to the Broadcom v3d driver some time back so update the matrix to
reflect that.