### PR TITLE
fix: use a full CSS solution for the "Fork me on GitHub" ribbon

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,8 @@ Mesamatrix is available under the AGPLv3, a copy of which is available in the
 * [jQuery Tipsy](http://onehackoranother.com/projects/jquery/tipsy/) is
   available under the MIT License.
 * PSR Log is available under the MIT License.
+* [Fork me on GitHub](https://simonwhitaker.github.io/github-fork-ribbon-css/)
+  is available under the MIT License.
 * [Symfony](https://symfony.com/) is available under the MIT License.
 
 ### Media files
@@ -127,5 +129,3 @@ Go tweak it, and send us your improvements!
 
 The RSS feed icon is freely available from the Mozilla Foundation at
 <http://www.feedicons.com/>.
-
-The GitHub 'Fork me' ribbon is available under the MIT license.

--- a/public/css/gh-fork-ribbon.css
+++ b/public/css/gh-fork-ribbon.css
@@ -1,0 +1,124 @@
+/*!
+ * "Fork me on GitHub" CSS ribbon v0.2.3 | MIT License
+ * https://github.com/simonwhitaker/github-fork-ribbon-css
+*/
+
+.github-fork-ribbon {
+  width: 12.1em;
+  height: 12.1em;
+  position: absolute;
+  overflow: hidden;
+  top: 0;
+  right: 0;
+  z-index: 9999;
+  pointer-events: none;
+  font-size: 13px;
+  text-decoration: none;
+  text-indent: -999999px;
+}
+
+.github-fork-ribbon.fixed {
+  position: fixed;
+}
+
+.github-fork-ribbon:hover, .github-fork-ribbon:active {
+  background-color: rgba(0, 0, 0, 0.0);
+}
+
+.github-fork-ribbon:before, .github-fork-ribbon:after {
+  /* The right and left classes determine the side we attach our banner to */
+  position: absolute;
+  display: block;
+  width: 15.38em;
+  height: 1.54em;
+
+  top: 3.23em;
+  right: -3.23em;
+
+  -webkit-box-sizing: content-box;
+  -moz-box-sizing: content-box;
+  box-sizing: content-box;
+
+  -webkit-transform: rotate(45deg);
+  -moz-transform: rotate(45deg);
+  -ms-transform: rotate(45deg);
+  -o-transform: rotate(45deg);
+  transform: rotate(45deg);
+}
+
+.github-fork-ribbon:before {
+  content: "";
+
+  /* Add a bit of padding to give some substance outside the "stitching" */
+  padding: .38em 0;
+
+  /* Set the base colour */
+  background-color: #a00;
+
+  /* Set a gradient: transparent black at the top to almost-transparent black at the bottom */
+  background-image: -webkit-gradient(linear, left top, left bottom, from(rgba(0, 0, 0, 0)), to(rgba(0, 0, 0, 0.15)));
+  background-image: -webkit-linear-gradient(top, rgba(0, 0, 0, 0), rgba(0, 0, 0, 0.15));
+  background-image: -moz-linear-gradient(top, rgba(0, 0, 0, 0), rgba(0, 0, 0, 0.15));
+  background-image: -ms-linear-gradient(top, rgba(0, 0, 0, 0), rgba(0, 0, 0, 0.15));
+  background-image: -o-linear-gradient(top, rgba(0, 0, 0, 0), rgba(0, 0, 0, 0.15));
+  background-image: linear-gradient(to bottom, rgba(0, 0, 0, 0), rgba(0, 0, 0, 0.15));
+
+  /* Add a drop shadow */
+  -webkit-box-shadow: 0 .15em .23em 0 rgba(0, 0, 0, 0.5);
+  -moz-box-shadow: 0 .15em .23em 0 rgba(0, 0, 0, 0.5);
+  box-shadow: 0 .15em .23em 0 rgba(0, 0, 0, 0.5);
+
+  pointer-events: auto;
+}
+
+.github-fork-ribbon:after {
+  /* Set the text from the data-ribbon attribute */
+  content: attr(data-ribbon);
+
+  /* Set the text properties */
+  color: #fff;
+  font: 700 1em "Helvetica Neue", Helvetica, Arial, sans-serif;
+  line-height: 1.54em;
+  text-decoration: none;
+  text-shadow: 0 -.08em rgba(0, 0, 0, 0.5);
+  text-align: center;
+  text-indent: 0;
+
+  /* Set the layout properties */
+  padding: .15em 0;
+  margin: .15em 0;
+
+  /* Add "stitching" effect */
+  border-width: .08em 0;
+  border-style: dotted;
+  border-color: #fff;
+  border-color: rgba(255, 255, 255, 0.7);
+}
+
+.github-fork-ribbon.left-top, .github-fork-ribbon.left-bottom {
+  right: auto;
+  left: 0;
+}
+
+.github-fork-ribbon.left-bottom, .github-fork-ribbon.right-bottom {
+  top: auto;
+  bottom: 0;
+}
+
+.github-fork-ribbon.left-top:before, .github-fork-ribbon.left-top:after, .github-fork-ribbon.left-bottom:before, .github-fork-ribbon.left-bottom:after {
+  right: auto;
+  left: -3.23em;
+}
+
+.github-fork-ribbon.left-bottom:before, .github-fork-ribbon.left-bottom:after, .github-fork-ribbon.right-bottom:before, .github-fork-ribbon.right-bottom:after {
+  top: auto;
+  bottom: 3.23em;
+}
+
+.github-fork-ribbon.left-top:before, .github-fork-ribbon.left-top:after, .github-fork-ribbon.right-bottom:before, .github-fork-ribbon.right-bottom:after {
+  -webkit-transform: rotate(-45deg);
+  -moz-transform: rotate(-45deg);
+  -ms-transform: rotate(-45deg);
+  -o-transform: rotate(-45deg);
+  transform: rotate(-45deg);
+}

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -537,3 +537,7 @@ input:checked + .slider::before {
     margin-top: 1em;
     text-align: right;
 }
+
+.github-fork-ribbon:before {
+    background-color: #f80;
+}

--- a/src/Controller/BaseController.php
+++ b/src/Controller/BaseController.php
@@ -36,6 +36,7 @@ abstract class BaseController
 
     public function __construct()
     {
+        $this->addCssScript('css/gh-fork-ribbon.css');
         $this->addCssScript('css/style.css?v=' . (Mesamatrix::$config->getValue("info", "version")));
 
         $this->addJsScript('js/jquery-3.7.0.min.js');
@@ -189,9 +190,7 @@ HTML;
         echo <<<HTML
         </main>
         <footer>
-            <a id="github-ribbon" href="{$projectUrl}">
-                <img src="https://camo.githubusercontent.com/652c5b9acfaddf3a9c326fa6bde407b87f7be0f4/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f6f72616e67655f6666373630302e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_orange_ff7600.png" />
-            </a>
+            <a class="github-fork-ribbon" href="{$projectUrl}" data-ribbon="Fork me on GitHub" title="Fork me on GitHub">Fork me on GitHub</a>
             <div class="theme-switch-wrapper">
                 <label class="theme-switch" for="checkbox">
                     <input type="checkbox" id="checkbox" />

--- a/src/Controller/BaseController.php
+++ b/src/Controller/BaseController.php
@@ -115,7 +115,7 @@ abstract class BaseController
         <meta property="og:type" content="website" />
         <meta property="og:image" content="//mesamatrix.net/images/mesamatrix-logo.png" />
 
-        <link rel="shortcut icon" href="images/gears.png" />
+        <link rel="icon" href="images/gears.png" type="image/png" />
         <link rel="alternate" type="application/rss+xml" title="rss feed" href="rss.php" />
 HTML;
 


### PR DESCRIPTION
This MR fixes the GitHub ribbon. It uses a new, full CSS solution: https://simonwhitaker.github.io/github-fork-ribbon-css/

At the same time I improved a little bit the `<link rel="icon" ...>` tag to better follow the standards.

Fixes #322 