### PR TITLE
feat: add Dockerfile to easily deploy Mesamatrix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,49 @@
+#################
+## Build image
+##
+
+FROM alpine:3.22 AS build
+
+RUN apk add --no-cache composer
+
+WORKDIR /app
+
+RUN mkdir config public src vendor
+COPY config ./config/
+COPY public ./public/
+COPY scripts ./scripts/
+COPY src ./src/
+COPY vendor ./vendor/
+COPY \
+    composer.json \
+    composer.lock \
+    mesamatrixctl \
+    ./
+RUN rm -f ./public/features.xml
+
+RUN composer install --no-dev
+
+#################
+## Final image
+##
+
+FROM php:8.2-apache
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends git && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN mv "$PHP_INI_DIR/php.ini-production" "$PHP_INI_DIR/php.ini"
+
+# Uncomment if in development environment:
+# RUN mv "$PHP_INI_DIR/php.ini-development" "$PHP_INI_DIR/php.ini"
+# RUN rm /var/log/apache2/*
+
+# Point Apache to the public/ directory
+ENV APACHE_DOCUMENT_ROOT /var/www/html/public
+RUN sed -ri -e 's!/var/www/html!${APACHE_DOCUMENT_ROOT}!g' /etc/apache2/sites-available/*.conf
+RUN sed -ri -e 's!/var/www/!${APACHE_DOCUMENT_ROOT}!g' /etc/apache2/apache2.conf /etc/apache2/conf-available/*.conf
+
+# Copy Mesamatrix into /var/www/html/
+COPY --from=build /app/ /var/www/html/

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Mesamatrix requires the following software:
 
 * [Composer](https://getcomposer.org/)
 * [Git](https://git-scm.com)
-* [PHP](https://www.php.net/) 7.4 or higher, with these packages:
+* [PHP](https://www.php.net/) 8.2 or higher, with these packages:
   * [php-json](https://www.php.net/manual/book.json.php)
   * [php-xml](https://www.php.net/manual/book.simplexml.php)
 
@@ -26,16 +26,11 @@ Clone the Mesamatrix repository:
 git clone git@github.com:MightyCreak/mesamatrix.git
 ```
 
-Jump into the directory and install the dependencies with Composer:
+Jump into the directory and install all the dependencies with Composer:
 
 ```sh
 cd mesamatrix
-
-# In development:
 composer install
-
-# In production:
-composer install --no-dev
 ```
 
 ### Configuration (optional)
@@ -53,9 +48,9 @@ copy this contents:
 use Monolog\Logger as Log;
 
 $CONFIG = array(
-    "info" => array(
-        "log_level" => Log::DEBUG,
-    ),
+  "info" => array(
+    "log_level" => Log::DEBUG,
+  ),
 );
 ```
 
@@ -81,9 +76,7 @@ latest information from Mesa:
 These commands can be put into a crontab or similar scheduling facility, for
 automated operation of your Mesamatrix installation.
 
-### Set up the web server
-
-#### For developers
+### Run the PHP server
 
 As a developer, an easy way to spawn up a PHP server is by running this
 command:
@@ -91,15 +84,6 @@ command:
 ```sh
 php -S 0.0.0.0:8080 -t public
 ```
-
-#### For deployment
-
-In order to deploy Mesamatrix on a server, the web server root must point to
-the `public` directory. Be aware not to give access to more than just this
-directory.
-
-At this point, you are done! Open your site in a web browser, and hopefully you
-will see the matrix of Mesa features!
 
 ## CLI tool
 
@@ -110,6 +94,69 @@ output respectively.
 
 Run `./mesamatrixctl list` to see the available commands, or
 `./mesamatrixctl help` for more detailed help.
+
+## Deploy using a Docker image
+
+Here are the steps to deploy Mesamatrix using a Docker image:
+
+1. Build the image
+2. Run the image
+3. Initialize Mesamatrix
+4. Setup Cron
+
+Note: all these commands also work with `podman`.
+
+### Build the image
+
+To build the Docker image, run this command:
+
+```sh
+docker build -t mesamatrix .
+```
+
+### Run the image
+
+The following command will run the image in the background (`-d`), expose the
+internal port 80 to the port 8080 (`-p`), mount a host directory to the
+`private` directory (`-v`), and give it a name (`--name`):
+
+```sh
+docker run -d \
+  -p 8080:80 \
+  -v "/path/to/host/folder:/var/www/html/private/" \
+  --name mesamatrix \
+  mesamatrix:latest
+```
+
+### Initialize Mesamatrix
+
+Now that Mesamatrix is running in the background, run this command line to
+initialize the application:
+
+```sh
+docker exec -t mesamatrix sh -c "./mesamatrixctl setup && ./mesamatrixctl parse"
+```
+
+### Setup cron
+
+Now that the container runs, you probably want it to automatically fetch the
+`mesa` repository and parse its commits in order to update the data in your
+Mesamatrix website.
+
+There is a script that you can run within the container, like so:
+
+```sh
+docker exec -t mesamatrix scripts/cron.sh
+```
+
+Now what's left to do is to set up a cron job that will run this script
+regularly. On your server, run `sudo crontab -e` and add these lines at the end
+of the file:
+
+```cron
+# Update Mesamatrix
+*/15  *  * * *  docker exec -t mesamatrix scripts/cron.sh > /dev/null
+```
 
 ## License
 

--- a/scripts/cron.sh
+++ b/scripts/cron.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+## Cron script to update Mesamatrix.
+
+set -e
+
+base_dir=$(dirname "$0")
+
+cd "$base_dir/.."
+./mesamatrixctl fetch
+./mesamatrixctl parse


### PR DESCRIPTION
This MR changes and simplifies how to deploy Mesamatrix on a server.

There are now 4 simple steps to follow:
1. Build the image
2. Run the image
3. Initialize Mesamatrix
4. Setup Cron

See the README for more details.
