### PR TITLE
fix(docker): don't copy the vendor/ dir in the build stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,6 @@ COPY config ./config/
 COPY public ./public/
 COPY scripts ./scripts/
 COPY src ./src/
-COPY vendor ./vendor/
 COPY \
     composer.json \
     composer.lock \


### PR DESCRIPTION
This MR fixes a copypasta error that slipped in the previous MR (#330).

It was copying the `vendor/` directory in the build stage, although it's useless since the `composer` command line just after is doing just that. Also it's better not to pollute the stage image with unwanted data from the host.