### PR TITLE
fixup! banner.svg: Fix text color in dark mode

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -180,6 +180,7 @@ a:hover, a:active {
 header img.banner {
     width: 663px;
     height: 132px;
+    color: var(--text-color)
 }
 
 main p {

--- a/public/images/banner.svg
+++ b/public/images/banner.svg
@@ -411,7 +411,7 @@
      inkscape:groupmode="layer"
      transform="translate(0,42)">
     <g
-       style="font-size:40px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:var(--text-color);fill-opacity:1;stroke:none;font-family:Sans"
+       style="font-size:40px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:currentColor;fill-opacity:1;stroke:none;font-family:Sans"
        id="text3094"
        transform="translate(-0.5,13.5)">
       <path
@@ -579,7 +579,7 @@
          style="fill:url(#linearGradient3959);fill-opacity:1;filter:url(#filter4024)" />
     </g>
     <g
-       style="font-size:40px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:var(--text-color);fill-opacity:1;stroke:none;font-family:Sans"
+       style="font-size:40px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:currentColor;fill-opacity:1;stroke:none;font-family:Sans"
        id="text3098"
        transform="translate(-0.5,13.5)">
       <path


### PR DESCRIPTION
This version should actually work. `<img>` tags don't inherit CSS styles, which caused the previous solution to not work.