### PR TITLE
fix: use new URL for Vulkan docs

### DIFF
--- a/config/config.default.php
+++ b/config/config.default.php
@@ -38,7 +38,7 @@ $CONFIG = [
         "enabled" => true,
         "cache_file" => "urlcache.json",
         "opengl_base_url" => "https://registry.khronos.org/OpenGL/extensions/",
-        "vulkan_base_url" => "https://registry.khronos.org/vulkan/specs/latest/man/html/",
+        "vulkan_base_url" => "https://docs.vulkan.org/refpages/latest/refpages/source/",
     ],
 
     "git" => [


### PR DESCRIPTION
The old URL for the Vulkan docs was giving "301 Moved Permanently".