### PR TITLE
refactor: use better design pattern for loading config files

### DIFF
--- a/config/config.default.php
+++ b/config/config.default.php
@@ -16,7 +16,7 @@ use Monolog\Logger as Log;
  * Log::DEBUG
  */
 
-$CONFIG = [
+return [
     "info" => [
         "log_level" => Log::WARNING,
         "version" => "3.0",

--- a/src/Mesamatrix.php
+++ b/src/Mesamatrix.php
@@ -29,11 +29,11 @@ use Symfony\Component\HttpFoundation\Request as HTTPRequest;
 
 class Mesamatrix
 {
-    public static $serverRoot; // Path to root of installation
-    public static $configDir; // Path to configuration directory
-    public static $config; // Config object
-    public static $logger; // Logger
-    public static $request; // HTTP request object
+    public static string $serverRoot; // Path to root of installation
+    public static string $configDir; // Path to configuration directory
+    public static Config $config;
+    public static Logger $logger;
+    public static HTTPRequest $request;
 
     public static function init()
     {

--- a/tests/resources/config/config.default.php
+++ b/tests/resources/config/config.default.php
@@ -1,6 +1,6 @@
 <?php
 
-$CONFIG = [
+return [
     'test_section1' => [
         'key1' => 'test_value',
         'key2' => 'default_value',

--- a/tests/resources/config/config.php
+++ b/tests/resources/config/config.php
@@ -1,7 +1,7 @@
 <?php
 
-$CONFIG = array(
-    'test_section1' => array(
+return [
+    'test_section1' => [
         'key2' => 'overridden_value',
-    ),
-);
+    ],
+];


### PR DESCRIPTION
This PR uses a better design pattern for loading config files.

Instead of declaring a `$CONFIG` variable in the `config/config.default.php` (and `config/config.php`), the script simply returns an array, and doesn't declare any variable.

So instead of just including the config file using `@include`, and then looking into the `$CONFIG` variable, the script directly assigned the result of the included file in a variable (using `$var = require($file_path)`).

It's apparently a better practice for loading config files.