### PR TITLE
chore: replace deprecated log levels in Logger by Level::*

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,11 +66,11 @@ copy this contents:
 ```php
 <?php
 
-use Monolog\Logger as Log;
+use Monolog\Level;
 
 $CONFIG = array(
   "info" => array(
-    "log_level" => Log::DEBUG,
+    "log_level" => Level::Debug,
   ),
 );
 ```

--- a/config/config.default.php
+++ b/config/config.default.php
@@ -3,22 +3,22 @@
 // Default configuration for Mesamatrix.
 // Values can be overwritten in a user defined config/config.php file.
 
-use Monolog\Logger as Log;
+use Monolog\Level;
 
-/* available log levels:
- * Log::EMERGENCY
- * Log::ALERT
- * Log::CRITICAL
- * Log::ERROR
- * Log::WARNING (default)
- * Log::NOTICE
- * Log::INFO
- * Log::DEBUG
+/* Available log levels:
+ * Level::Emergency
+ * Level::Alert
+ * Level::Critical
+ * Level::Error
+ * Level::Warning (default)
+ * Level::Notice
+ * Level::Info
+ * Level::Debug
  */
 
 return [
     "info" => [
-        "log_level" => Log::WARNING,
+        "log_level" => Level::Warning,
         "version" => "3.0",
         "title" => "The Mesa drivers matrix",
         "description" => "Show Mesa progress for the OpenGL, OpenGL ES, Vulkan and OpenCL drivers implementations into an easy to read HTML page.",

--- a/src/Controller/RssController.php
+++ b/src/Controller/RssController.php
@@ -3,10 +3,10 @@
 namespace Mesamatrix\Controller;
 
 use Mesamatrix\Mesamatrix;
-use Symfony\Component\HttpFoundation\Response as HTTPResponse;
 use Suin\RSSWriter\Feed as RSSFeed;
 use Suin\RSSWriter\Channel as RSSChannel;
 use Suin\RSSWriter\Item as RSSItem;
+use Symfony\Component\HttpFoundation\Response as HttpResponse;
 
 class RssController
 {
@@ -37,9 +37,9 @@ class RssController
         }
 
         // Send response.
-        $response = new HTTPResponse(
+        $response = new HttpResponse(
             $rssContents,
-            HTTPResponse::HTTP_OK,
+            HttpResponse::HTTP_OK,
             ['Content-Type' => 'text/xml']
         );
 
@@ -61,7 +61,7 @@ class RssController
         return true;
     }
 
-    private function generateRss(string $featuresXmlFilepath): string
+    private function generateRss(string $featuresXmlFilepath): ?string
     {
         $xml = simplexml_load_file($featuresXmlFilepath);
         if (!$xml) {

--- a/src/Mesamatrix.php
+++ b/src/Mesamatrix.php
@@ -21,11 +21,12 @@
 
 namespace Mesamatrix;
 
+use Monolog\Level;
 use Monolog\Logger;
 use Monolog\ErrorHandler;
 use Monolog\Handler\ErrorLogHandler;
 use Monolog\Handler\StreamHandler;
-use Symfony\Component\HttpFoundation\Request as HTTPRequest;
+use Symfony\Component\HttpFoundation\Request as HttpRequest;
 
 class Mesamatrix
 {
@@ -33,7 +34,7 @@ class Mesamatrix
     public static string $configDir; // Path to configuration directory
     public static Config $config;
     public static Logger $logger;
-    public static HTTPRequest $request;
+    public static HttpRequest $request;
 
     public static function init()
     {
@@ -44,7 +45,7 @@ class Mesamatrix
         self::$logger = new Logger('logger');
         self::$logger->pushHandler(new ErrorLogHandler(
             ErrorLogHandler::OPERATING_SYSTEM,
-            Logger::NOTICE
+            Level::Notice
         ));
         ErrorHandler::register(self::$logger);
 
@@ -58,7 +59,7 @@ class Mesamatrix
         }
 
         // register the log file
-        $logLevel = self::$config->getValue('info', 'log_level', Logger::WARNING);
+        $logLevel = self::$config->getValue('info', 'log_level', Level::Warning);
         $logPath = $privateDir . '/mesamatrix.log';
         if (!file_exists($logPath) && is_dir($privateDir)) {
             touch($logPath);
@@ -70,7 +71,7 @@ class Mesamatrix
             self::$logger->error('Error log ' . $logPath . ' is not writable!');
         }
 
-        if ($logLevel < Logger::INFO) {
+        if ($logLevel < Level::Info) {
             ini_set('display_errors', '1');
             error_reporting(E_ALL);
         }
@@ -82,11 +83,11 @@ class Mesamatrix
         }
 
         // Initialize request
-        self::$request = HTTPRequest::createFromGlobals();
+        self::$request = HttpRequest::createFromGlobals();
 
         self::$logger->debug('Base initialization complete');
 
-        self::$logger->debug('Log level: ' . self::$logger->getLevelName($logLevel));
+        self::$logger->debug('Log level: ' . Logger::toMonologLevel($logLevel)->getName());
         self::$logger->debug('PHP error_reporting: 0x' . dechex(ini_get('error_reporting')));
         self::$logger->debug('PHP display_errors: ' . ini_get('display_errors'));
     }


### PR DESCRIPTION
Log levels, like `Monolog\Logger::WARNING`, are deprecated and should be replaced by their counterparts in the `Level` enum, like so: `Monolog\Level::Warning`.