### PR TITLE
Parse OpenCL 3.1 entries

### DIFF
--- a/src/Console/Command/Parse.php
+++ b/src/Console/Command/Parse.php
@@ -65,6 +65,7 @@ class Parse extends Command
         Constants::RUSTICL_OPENCL_NAME => [
             Constants::RUSTICL_OPENCL_NAME,
             Constants::RUSTICL_OPENCL_EXTRA_NAME,
+            Constants::RUSTICL_OPENCL_CL3_1_NAME,
             Constants::RUSTICL_OPENCL_CL2_OPTIONAL_NAME,
             Constants::RUSTICL_OPENCL_OPTIONAL_NAME,
         ],
@@ -529,6 +530,7 @@ class Parse extends Command
 
             case Constants::RUSTICL_OPENCL_NAME:
             case Constants::RUSTICL_OPENCL_OPTIONAL_NAME:
+            case Constants::RUSTICL_OPENCL_CL3_1_NAME:
             case Constants::RUSTICL_OPENCL_CL2_OPTIONAL_NAME:
             case Constants::RUSTICL_OPENCL_EXTRA_NAME:
                 $vendors = Constants::RUSTICL_OPENCL_ALL_DRIVERS_VENDORS;

--- a/src/Parser/ApiVersion.php
+++ b/src/Parser/ApiVersion.php
@@ -110,6 +110,7 @@ class ApiVersion
 
             case Constants::RUSTICL_OPENCL_NAME:
             case Constants::RUSTICL_OPENCL_OPTIONAL_NAME:
+            case Constants::RUSTICL_OPENCL_CL3_1_NAME:
             case Constants::RUSTICL_OPENCL_CL2_OPTIONAL_NAME:
             case Constants::RUSTICL_OPENCL_EXTRA_NAME:
                 return Constants::RUSTICL_OPENCL_ALL_DRIVERS;

--- a/src/Parser/Constants.php
+++ b/src/Parser/Constants.php
@@ -104,6 +104,7 @@ abstract class Constants
     // OpenCL.
     public const RUSTICL_OPENCL_NAME = 'Rusticl OpenCL';
     public const RUSTICL_OPENCL_OPTIONAL_NAME = 'Rusticl Optional Core Features';
+    public const RUSTICL_OPENCL_CL3_1_NAME = 'Rusticl OpenCL 3.1 Features';
     public const RUSTICL_OPENCL_CL2_OPTIONAL_NAME = 'Rusticl Optional OpenCL 2.x Features';
     public const RUSTICL_OPENCL_EXTRA_NAME = 'Rusticl Extensions';
     public const RUSTICL_OPENCL_ALL_DRIVERS = [

--- a/src/Parser/Parser.php
+++ b/src/Parser/Parser.php
@@ -125,6 +125,13 @@ class Parser
                         $apiVersion = new ApiVersion($openClName, null, null, null, $matrix->getHints());
                         $matrix->addApiVersion($apiVersion);
                     }
+                } elseif ($line === self::RUSTICL_OPENCL_CL3_1) {
+                    $openClName = Constants::RUSTICL_OPENCL_CL3_1_NAME;
+                    $apiVersion = $matrix->getApiVersionByName($openClName, null);
+                    if (!$apiVersion) {
+                        $apiVersion = new ApiVersion($openClName, null, null, null, $matrix->getHints());
+                        $matrix->addApiVersion($apiVersion);
+                    }
                 } elseif ($line === self::RUSTICL_OPENCL_CL2_OPTIONAL) {
                     $openClName = Constants::RUSTICL_OPENCL_CL2_OPTIONAL_NAME;
                     $apiVersion = $matrix->getApiVersionByName($openClName, null);
@@ -427,6 +434,8 @@ class Parser
         "Khronos extensions that are not part of any Vulkan version:\n";
     private const RUSTICL_OPENCL_CORE_OPTIONAL =
         "Rusticl Optional Core Features:\n";
+    private const RUSTICL_OPENCL_CL3_1 =
+        "Rusticl OpenCL 3.1 Features:\n";
     private const RUSTICL_OPENCL_CL2_OPTIONAL =
         "Rusticl Optional OpenCL 2.x Features:\n";
     private const RUSTICL_OPENCL_EXTENSIONS =


### PR DESCRIPTION
Updated needed due to https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/41358 and the release of OpenCL 3.1

<img width="2046" height="1726" alt="image" src="https://github.com/user-attachments/assets/6b6b3742-4554-49c7-aac7-34f08315c0a3" />
