### PR TITLE
feat: sticky headers

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -236,7 +236,7 @@ details > summary {
     border-collapse: separate;
 }
 
-.hCellHeader {
+.matrix .hCellHeader {
     font-size: 85%;
     min-width: 4.1em;
     padding: 0.2em;
@@ -245,54 +245,51 @@ details > summary {
     cursor: default;
 }
 
-.hCellDriverScore {
+.matrix .hCellDriverScore {
     font-size: 85%;
     font-weight: bold;
     color: #DDDDDD;
     cursor: default;
 }
 
-.hCellDriverScore-done { color: #99D75F; }
-.hCellDriverScore-almost { color: #E1A25E; }
-.hCellDriverScore-notyet { color: #B94B3D; }
+.matrix .hCellVendor-default        { background-color: var(--matrix-ext-default-color); }
+.matrix .hCellVendor-amd            { background-color: var(--matrix-ext-amd-color); }
+.matrix .hCellVendor-apple          { background-color: var(--matrix-ext-apple-color); }
+.matrix .hCellVendor-arm            { background-color: var(--matrix-ext-arm-color); }
+.matrix .hCellVendor-broadcom       { background-color: var(--matrix-ext-broadcom-color); }
+.matrix .hCellVendor-intel          { background-color: var(--matrix-ext-intel-color); }
+.matrix .hCellVendor-nvidia         { background-color: var(--matrix-ext-nvidia-color); }
+.matrix .hCellVendor-powervr        { background-color: var(--matrix-ext-powervr-color); }
+.matrix .hCellVendor-qualcomm       { background-color: var(--matrix-ext-qualcomm-color); }
+.matrix .hCellVendor-software       { background-color: var(--matrix-ext-software-color); }
+.matrix .hCellVendor-translation    { background-color: var(--matrix-ext-translation-color); }
+.matrix .hCellVendor-vivante        { background-color: var(--matrix-ext-vivante-color); }
 
-.hCellVendor-default        { background-color: var(--matrix-ext-default-color); }
-.hCellVendor-amd            { background-color: var(--matrix-ext-amd-color); }
-.hCellVendor-apple          { background-color: var(--matrix-ext-apple-color); }
-.hCellVendor-arm            { background-color: var(--matrix-ext-arm-color); }
-.hCellVendor-broadcom       { background-color: var(--matrix-ext-broadcom-color); }
-.hCellVendor-intel          { background-color: var(--matrix-ext-intel-color); }
-.hCellVendor-nvidia         { background-color: var(--matrix-ext-nvidia-color); }
-.hCellVendor-powervr        { background-color: var(--matrix-ext-powervr-color); }
-.hCellVendor-qualcomm       { background-color: var(--matrix-ext-qualcomm-color); }
-.hCellVendor-software       { background-color: var(--matrix-ext-software-color); }
-.hCellVendor-translation    { background-color: var(--matrix-ext-translation-color); }
-.hCellVendor-vivante        { background-color: var(--matrix-ext-vivante-color); }
+.matrix .hCellSep {
+    width: 0px;
+}
 
-.hCellSep       { width: 0px; }
+.matrix .hCellDriverScore-done      { color: #99D75F; }
+.matrix .hCellDriverScore-almost    { color: #E1A25E; }
+.matrix .hCellDriverScore-notyet    { color: #B94B3D; }
 
-.permalink { margin-left: 0.3em; visibility: hidden; }
-.permalink:link { text-decoration: none; color: #DDDDDD; }
-.permalink:visited { text-decoration: none; color: #DDDDDD; }
-:hover > .permalink { visibility: visible; }
-
-.extension {
+.matrix .extension {
     font-size: 85%;
 }
-.extension > td.hover {
+.matrix .extension > td.hover {
     opacity: 0.75;
 }
-.extension > td:first-of-type {
+.matrix .extension > td:first-of-type {
     min-width: 32em;
 }
-.extension > td:first-of-type.hover {
+.matrix .extension > td:first-of-type.hover {
     background-color: var(--matrix-ext-hover-color);
     opacity: 1.0;
 }
 
-.extension-child { padding-left: 1em; }
+.matrix .extension-child { padding-left: 1em; }
 
-.task {
+.matrix .task {
     position: relative;
     padding-right: 4px;
     height: 1.3em;
@@ -300,7 +297,7 @@ details > summary {
     cursor: default;
     text-align: center;
 }
-.task span {
+.matrix .task span {
     position: absolute;
     bottom: 0;
     right: 0;
@@ -309,23 +306,32 @@ details > summary {
     color: black;
 }
 
-.isDone { background-color: #A7E969; }
-.isInProgress { background-color: #E99D4A; }
-.isNotStarted { background-color: #D55E4F; }
+.matrix .isDone { background-color: #A7E969; }
+.matrix .isInProgress { background-color: #E99D4A; }
+.matrix .isNotStarted { background-color: #D55E4F; }
 
-.footnote.task {
+.matrix .footnote.task {
     padding: 0;
     cursor: help;
 }
-.footnote.isDone {
+.matrix .footnote.isDone {
     background: repeating-linear-gradient(45deg, #A7E969, #A7E969 10px, #97C86A 10px, #97C86A 20px);
 }
-.footnote.isInProgress {
+.matrix .footnote.isInProgress {
     background: repeating-linear-gradient(45deg, #E99D4A, #E99D4A 10px, #C9853F 10px, #C9853F 20px);
 }
-.footnote.isNotStarted {
+.matrix .footnote.isNotStarted {
     background: repeating-linear-gradient(45deg, #D86758, #D86758 10px, #AA574C 10px, #AA574C 20px);
 }
+
+/**
+ * Permalinks
+ */
+
+.permalink { margin-left: 0.3em; visibility: hidden; }
+.permalink:link { text-decoration: none; color: #DDDDDD; }
+.permalink:visited { text-decoration: none; color: #DDDDDD; }
+:hover > .permalink { visibility: visible; }
 
 /**
  * Menu

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -229,14 +229,35 @@ details > summary {
     border-radius: 0.2em;
     padding: 0 0.5em 0.5em 0.5em;
     overflow: auto; /* Enables both horizontal and vertical scrolling */
+    height: 90vh;
 }
 
 .matrix {
-    border-spacing: 1px;
+    border-spacing: 0;
     border-collapse: separate;
 }
 
+.matrix thead {
+    background-color: var(--bkg-color);
+    position: sticky;
+    top: 0;
+    z-index: 2;
+}
+
+.matrix tr:first-child th {
+    padding-top: 0.7em;
+}
+
+.matrix th:first-child {
+    border-left: 0;
+}
+
+.matrix td:not(:first-child) {
+    border-left: 1px solid var(--bkg-color);
+}
+
 .matrix .hCellHeader {
+    border-left: 1px solid var(--bkg-color);
     font-size: 85%;
     min-width: 4.1em;
     padding: 0.2em;
@@ -248,7 +269,7 @@ details > summary {
 .matrix .hCellDriverScore {
     font-size: 85%;
     font-weight: bold;
-    color: #DDDDDD;
+    text-align: center;
     cursor: default;
 }
 
@@ -276,6 +297,9 @@ details > summary {
 .matrix .extension {
     font-size: 85%;
 }
+.matrix .extension td:not(:first-child) {
+    border-top: 1px solid var(--bkg-color);
+}
 .matrix .extension > td.hover {
     opacity: 0.75;
 }
@@ -291,7 +315,6 @@ details > summary {
 
 .matrix .task {
     position: relative;
-    padding-right: 4px;
     height: 1.3em;
     padding: 0;
     cursor: default;

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -212,9 +212,8 @@ main p {
  */
 
 details {
-    display: inline;
-    padding-top: 1em;
-    padding-bottom: 1em;
+    margin-top: 1em;
+    margin-bottom: 1em;
 }
 
 details > summary {

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -223,6 +223,14 @@ details > summary {
     cursor: pointer;
 }
 
+/* Scrollable container */
+.matrix-container {
+    border: 1px solid var(--text-color);
+    border-radius: 0.2em;
+    padding: 0 0.5em 0.5em 0.5em;
+    overflow: auto; /* Enables both horizontal and vertical scrolling */
+}
+
 .matrix {
     border-spacing: 1px;
     border-collapse: separate;

--- a/public/js/script.js
+++ b/public/js/script.js
@@ -116,22 +116,6 @@ function manageDates() {
     });
 }
 
-function manageScores() {
-    // Change mesa score color based on completion
-    $('.hCellDriverScore').each(function() {
-        var blend = Math.round($(this).data('score'));
-        if (blend == 100) {
-            $(this).addClass('hCellDriverScore-done');
-        }
-        else if (blend < 75) {
-            $(this).addClass('hCellDriverScore-notyet');
-        }
-        else {
-            $(this).addClass('hCellDriverScore-almost');
-        }
-    });
-}
-
 function manageMatrixCellsHighlight() {
     $('.matrix').delegate('td', 'mouseover mouseleave', function(e) {
         // Get cell, row and table elements
@@ -216,7 +200,6 @@ function manageTheme() {
 $(document).ready(function () {
     manageTheme();
     manageDates();
-    manageScores();
     manageMatrixCellsHighlight();
 
     // Add tipsy for the footnote.

--- a/src/Controller/ApiSubController.php
+++ b/src/Controller/ApiSubController.php
@@ -350,6 +350,60 @@ HTML;
                 endforeach;
             endforeach;
 
+            echo <<<'HTML'
+                <thead>
+                    <tr>
+HTML;
+
+            // Header (vendors).
+            foreach ($this->matrix['column_groups'] as $colgroup) :
+                if (empty($colgroup['name'])) :
+                    echo <<<'HTML'
+                        <th></th>
+HTML;
+                else :
+                    $colspan = count($colgroup['columns']);
+                    $colgroupName = $colgroup['name'];
+                    $vendorClass = "hCellVendor-" . $colgroup['vendor_class'];
+
+                    echo <<<HTML
+                        <th colspan="{$colspan}" class="hCellHeader hCellVendor-{$vendorClass}">{$colgroupName}</th>
+HTML;
+                endif;
+            endforeach;
+
+            echo <<<'HTML'
+                    </tr>
+                    <tr>
+HTML;
+
+            // Header (drivers).
+            foreach ($this->matrix['columns'] as $col) :
+                if ($col['type'] === 'extension') :
+                    echo <<<HTML
+                        <th class="hCellHeader hCellVendor-default">{$col['name']}</th>
+HTML;
+                elseif ($col['type'] === 'driver') :
+                    echo <<<HTML
+                        <th class="hCellHeader hCellVendor-{$col['vendor_class']}">{$col['name']}</th>
+HTML;
+                elseif ($col['type'] === 'separator') :
+                    echo <<<'HTML'
+                        <th class="hCellSep"></th>
+HTML;
+                else :
+                    echo <<<HTML
+                        <th>{$col['name']}</th>
+HTML;
+                endif;
+            endforeach;
+
+            echo <<<'HTML'
+                    </tr>
+                </thead>
+                <tbody>
+HTML;
+
             // Sub-sections.
             $numColumns = count($this->matrix['columns']);
             foreach ($section['subsections'] as $subsection) :
@@ -358,64 +412,16 @@ HTML;
 
                 if (!empty($subsectionName)) :
                     echo <<<HTML
-                <tr>
-                    <td colspan="{$numColumns}">
-                        <h2 id="{$subsectionId}">{$subsectionName}<a href="#{$subsectionId}" class="permalink">&para;</a></h2>
-                    </td>
-                </tr>
+                    <tr>
+                        <td colspan="{$numColumns}">
+                            <h2 id="{$subsectionId}">{$subsectionName}<a href="#{$subsectionId}" class="permalink">&para;</a></h2>
+                        </td>
+                    </tr>
 HTML;
                 endif;
 
                 echo <<<'HTML'
-                <tr>
-HTML;
-
-                // Header (vendors).
-                foreach ($this->matrix['column_groups'] as $colgroup) :
-                    if (empty($colgroup['name'])) :
-                        echo <<<'HTML'
-                    <td></td>
-HTML;
-                    else :
-                        $colspan = count($colgroup['columns']);
-                        $colgroupName = $colgroup['name'];
-                        $vendorClass = "hCellVendor-" . $colgroup['vendor_class'];
-
-                        echo <<<HTML
-                    <td colspan="{$colspan}" class="hCellHeader hCellVendor-{$vendorClass}">{$colgroupName}</td>
-HTML;
-                    endif;
-                endforeach;
-
-                echo <<<'HTML'
-                </tr>
-                <tr>
-HTML;
-
-                // Header (drivers).
-                foreach ($this->matrix['columns'] as $col) :
-                    if ($col['type'] === 'extension') :
-                        echo <<<HTML
-                    <td class="hCellHeader hCellVendor-default">{$col['name']}</td>
-HTML;
-                    elseif ($col['type'] === 'driver') :
-                        echo <<<HTML
-                    <td class="hCellHeader hCellVendor-{$col['vendor_class']}">{$col['name']}</td>
-HTML;
-                    elseif ($col['type'] === 'separator') :
-                        echo <<<'HTML'
-                    <td class="hCellSep"></td>
-HTML;
-                    else :
-                        echo <<<HTML
-                    <td>{$col['name']}</td>
-HTML;
-                    endif;
-                endforeach;
-
-                echo <<<'HTML'
-                </tr>
-                <tr>
+                    <tr>
 HTML;
 
                 // Scores.
@@ -423,23 +429,23 @@ HTML;
                     if ($col['type'] === 'driver') :
                         $scoreStr = sprintf('%.1f', $subsection['scores'][$col['name']] * 100);
                         echo <<<HTML
-                    <td class="hCellHeader hCellDriverScore" data-score="{$scoreStr}">{$scoreStr}%</td>
+                        <td class="{$scoreClasses}" data-score="{$scoreStr}">{$scoreStr}%</td>
 HTML;
                     else :
                         echo <<<'HTML'
-                    <td></td>
+                        <td></td>
 HTML;
                     endif;
                 endforeach;
 
                 echo <<<'HTML'
-                </tr>
+                    </tr>
 HTML;
 
                 // Extensions.
                 foreach ($subsection['extensions'] as $extension) :
                     echo <<<'HTML'
-                <tr class="extension">
+                    <tr class="extension">
 HTML;
                     foreach ($this->matrix['columns'] as $col) :
                         if ($col['type'] === 'extension') :
@@ -452,9 +458,9 @@ HTML;
                                 $cssClass = ' class="extension-child"';
                             endif;
                             echo <<<HTML
-                    <td id="{$extension['target']}"{$cssClass}>
-                        {$extNameText}<a href="#{$extension['target']}" class="permalink">&para;</a>
-                    </td>
+                        <td id="{$extension['target']}"{$cssClass}>
+                            {$extNameText}<a href="#{$extension['target']}" class="permalink">&para;</a>
+                        </td>
 HTML;
                         elseif ($col['type'] === 'driver') :
                             $driverTask = $extension['tasks'][$col['name']];
@@ -467,30 +473,31 @@ HTML;
 
                             $cssClassesStr = join(' ', $cssClasses);
                             echo <<<HTML
-                    <td class="{$cssClassesStr}"{$title}>
+                        <td class="{$cssClassesStr}"{$title}>
 HTML;
                             if (isset($driverTask['timestamp'])) :
                                 $date = date('Y-m-d', $driverTask['timestamp']);
                                 echo <<<HTML
-                        <span data-timestamp="{$driverTask['timestamp']}">{$date}</span>
+                            <span data-timestamp="{$driverTask['timestamp']}">{$date}</span>
 HTML;
                             endif;
                             echo <<<'HTML'
-                    </td>
+                        </td>
 HTML;
                         else :
                             echo <<<'HTML'
-                    <td></td>
+                        <td></td>
 HTML;
                         endif;
                     endforeach;
                     echo <<<'HTML'
-                </tr>
+                    </tr>
 HTML;
                 endforeach;
             endforeach;
         endforeach;
         echo <<<'HTML'
+                </tbody>
             </table>
         </div>
     </details>

--- a/src/Controller/ApiSubController.php
+++ b/src/Controller/ApiSubController.php
@@ -330,7 +330,8 @@ HTML;
             echo <<<'HTML'
     <details>
         <summary>Drivers details</summary>
-        <table class="matrix">
+        <div class="matrix-container">
+            <table class="matrix">
 HTML;
 
             // Colgroups.
@@ -339,11 +340,11 @@ HTML;
                     $col = $this->matrix['columns'][$colIdx];
                     if ($col['type'] === 'driver') :
                         echo <<<'HTML'
-            <colgroup class="hl">
+                <colgroup class="hl">
 HTML;
                     else :
                         echo <<<'HTML'
-            <colgroup>
+                <colgroup>
 HTML;
                     endif;
                 endforeach;
@@ -357,23 +358,23 @@ HTML;
 
                 if (!empty($subsectionName)) :
                     echo <<<HTML
-            <tr>
-                <td colspan="{$numColumns}">
-                    <h2 id="{$subsectionId}">{$subsectionName}<a href="#{$subsectionId}" class="permalink">&para;</a></h2>
-                </td>
-            </tr>
+                <tr>
+                    <td colspan="{$numColumns}">
+                        <h2 id="{$subsectionId}">{$subsectionName}<a href="#{$subsectionId}" class="permalink">&para;</a></h2>
+                    </td>
+                </tr>
 HTML;
                 endif;
 
                 echo <<<'HTML'
-            <tr>
+                <tr>
 HTML;
 
                 // Header (vendors).
                 foreach ($this->matrix['column_groups'] as $colgroup) :
                     if (empty($colgroup['name'])) :
                         echo <<<'HTML'
-                <td></td>
+                    <td></td>
 HTML;
                     else :
                         $colspan = count($colgroup['columns']);
@@ -381,40 +382,40 @@ HTML;
                         $vendorClass = "hCellVendor-" . $colgroup['vendor_class'];
 
                         echo <<<HTML
-                <td colspan="{$colspan}" class="hCellHeader hCellVendor-{$vendorClass}">{$colgroupName}</td>
+                    <td colspan="{$colspan}" class="hCellHeader hCellVendor-{$vendorClass}">{$colgroupName}</td>
 HTML;
                     endif;
                 endforeach;
 
                 echo <<<'HTML'
-            </tr>
-            <tr>
+                </tr>
+                <tr>
 HTML;
 
                 // Header (drivers).
                 foreach ($this->matrix['columns'] as $col) :
                     if ($col['type'] === 'extension') :
                         echo <<<HTML
-                <td class="hCellHeader hCellVendor-default">{$col['name']}</td>
+                    <td class="hCellHeader hCellVendor-default">{$col['name']}</td>
 HTML;
                     elseif ($col['type'] === 'driver') :
                         echo <<<HTML
-                <td class="hCellHeader hCellVendor-{$col['vendor_class']}">{$col['name']}</td>
+                    <td class="hCellHeader hCellVendor-{$col['vendor_class']}">{$col['name']}</td>
 HTML;
                     elseif ($col['type'] === 'separator') :
                         echo <<<'HTML'
-                <td class="hCellSep"></td>
+                    <td class="hCellSep"></td>
 HTML;
                     else :
                         echo <<<HTML
-                <td>{$col['name']}</td>
+                    <td>{$col['name']}</td>
 HTML;
                     endif;
                 endforeach;
 
                 echo <<<'HTML'
-            </tr>
-            <tr>
+                </tr>
+                <tr>
 HTML;
 
                 // Scores.
@@ -422,23 +423,23 @@ HTML;
                     if ($col['type'] === 'driver') :
                         $scoreStr = sprintf('%.1f', $subsection['scores'][$col['name']] * 100);
                         echo <<<HTML
-                <td class="hCellHeader hCellDriverScore" data-score="{$scoreStr}">{$scoreStr}%</td>
+                    <td class="hCellHeader hCellDriverScore" data-score="{$scoreStr}">{$scoreStr}%</td>
 HTML;
                     else :
                         echo <<<'HTML'
-                <td></td>
+                    <td></td>
 HTML;
                     endif;
                 endforeach;
 
                 echo <<<'HTML'
-            </tr>
+                </tr>
 HTML;
 
                 // Extensions.
                 foreach ($subsection['extensions'] as $extension) :
                     echo <<<'HTML'
-            <tr class="extension">
+                <tr class="extension">
 HTML;
                     foreach ($this->matrix['columns'] as $col) :
                         if ($col['type'] === 'extension') :
@@ -451,9 +452,9 @@ HTML;
                                 $cssClass = ' class="extension-child"';
                             endif;
                             echo <<<HTML
-                <td id="{$extension['target']}"{$cssClass}>
-                    {$extNameText}<a href="#{$extension['target']}" class="permalink">&para;</a>
-                </td>
+                    <td id="{$extension['target']}"{$cssClass}>
+                        {$extNameText}<a href="#{$extension['target']}" class="permalink">&para;</a>
+                    </td>
 HTML;
                         elseif ($col['type'] === 'driver') :
                             $driverTask = $extension['tasks'][$col['name']];
@@ -466,31 +467,32 @@ HTML;
 
                             $cssClassesStr = join(' ', $cssClasses);
                             echo <<<HTML
-                <td class="{$cssClassesStr}"{$title}>
+                    <td class="{$cssClassesStr}"{$title}>
 HTML;
                             if (isset($driverTask['timestamp'])) :
                                 $date = date('Y-m-d', $driverTask['timestamp']);
                                 echo <<<HTML
-                    <span data-timestamp="{$driverTask['timestamp']}">{$date}</span>
+                        <span data-timestamp="{$driverTask['timestamp']}">{$date}</span>
 HTML;
                             endif;
                             echo <<<'HTML'
-                </td>
+                    </td>
 HTML;
                         else :
                             echo <<<'HTML'
-                <td></td>
+                    <td></td>
 HTML;
                         endif;
                     endforeach;
                     echo <<<'HTML'
-            </tr>
+                </tr>
 HTML;
                 endforeach;
             endforeach;
         endforeach;
         echo <<<'HTML'
-        </table>
+            </table>
+        </div>
     </details>
 HTML;
     }

--- a/src/Controller/ApiSubController.php
+++ b/src/Controller/ApiSubController.php
@@ -427,9 +427,18 @@ HTML;
                 // Scores.
                 foreach ($this->matrix['columns'] as $col) :
                     if ($col['type'] === 'driver') :
-                        $scoreStr = sprintf('%.1f', $subsection['scores'][$col['name']] * 100);
+                        $score = $subsection['scores'][$col['name']];
+                        $scoreStr = sprintf('%.1f', $score * 100);
+                        $scoreClasses = "hCellDriverScore";
+                        if ($score == 1.0) :
+                            $scoreClasses .= " hCellDriverScore-done";
+                        elseif ($score >= 0.75) :
+                            $scoreClasses .= " hCellDriverScore-almost";
+                        else :
+                            $scoreClasses .= " hCellDriverScore-notyet";
+                        endif;
                         echo <<<HTML
-                        <td class="{$scoreClasses}" data-score="{$scoreStr}">{$scoreStr}%</td>
+                        <td class="{$scoreClasses}">{$scoreStr}%</td>
 HTML;
                     else :
                         echo <<<'HTML'


### PR DESCRIPTION
This PR changes how the big drivers/extensions tables are displayed. Instead of repeating the header rows at each subsection, the headers rows are "sticked" to the top.

When expanding the table, it is now showed in a restricted block that fits the screen width and is 90% of the screen height. This enables scrollable view, which allows for the sticky headers.