### PR TITLE
feat: add user-agent when testing extension URLs

### DIFF
--- a/public/bot.php
+++ b/public/bot.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of mesamatrix.
+ *
+ * Copyright (C) 2014-2026 Romain "Creak" Failliot.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+require_once "../src/base.php";
+
+$controller = new Mesamatrix\Controller\BotController();
+$controller->writeHtml();

--- a/src/Controller/BaseController.php
+++ b/src/Controller/BaseController.php
@@ -33,6 +33,7 @@ abstract class BaseController
         "About" => "about.php",
         "Donate?" => "donate.php");
 
+    private bool $showMenu = true;
     private int $pageIdx = -1;
 
     /** @var string[] */
@@ -48,6 +49,11 @@ abstract class BaseController
 
         $this->addJsScript('js/jquery-3.7.0.min.js');
         $this->addJsScript('js/script.js');
+    }
+
+    final protected function setShowMenu(bool $showMenu): void
+    {
+        $this->showMenu = $showMenu;
     }
 
     /**
@@ -143,30 +149,36 @@ HTML;
     <body>
         <header>
             <a href="."><img src="images/banner.svg" class="banner" alt="Mesamatrix banner" /></a>
+HTML;
 
+        if ($this->showMenu) :
+            echo <<<'HTML'
             <div class="menu">
                 <ul class="menu-list">
 HTML;
-        $i = 0;
-        foreach ($this->pages as $page => $link) :
-            $item = "<a href=\"" . $link . "\">" . $page . "</a>";
-            if ($i === $this->pageIdx) :
-                echo <<<HTML
-                    <li class="menu-selected">{$item}</li>
+            $i = 0;
+            foreach ($this->pages as $page => $link) :
+                $item = "<a href=\"" . $link . "\">" . $page . "</a>";
+                if ($i === $this->pageIdx) :
+                    echo <<<HTML
+                        <li class="menu-selected">{$item}</li>
 HTML;
-            else :
-                echo <<<HTML
-                    <li><a href="{$link}">{$page}</a></li>
+                else :
+                    echo <<<HTML
+                        <li><a href="{$link}">{$page}</a></li>
 HTML;
-            endif;
-            ++$i;
-        endforeach;
+                endif;
+                ++$i;
+            endforeach;
 
-        echo <<<'HTML'
+            echo <<<'HTML'
                     <li><a href="rss.php" class="rss"><img class="rss" src="images/feed.svg" alt="RSS feed" /></a></li>
                 </ul>
             </div>
+HTML;
+        endif;
 
+        echo <<<'HTML'
 <!-- Matomo -->
 <script>
   var _paq = window._paq = window._paq || [];

--- a/src/Controller/BotController.php
+++ b/src/Controller/BotController.php
@@ -1,0 +1,54 @@
+<?php
+
+/*
+ * This file is part of mesamatrix.
+ *
+ * Copyright (C) 2014-2022 Romain "Creak" Failliot.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace Mesamatrix\Controller;
+
+class BotController extends BaseController
+{
+    public function __construct()
+    {
+        parent::__construct();
+
+        $this->setShowMenu(false);
+    }
+
+    protected function computeRendering(): void
+    {
+    }
+
+    protected function writeHtmlPage(): void
+    {
+        echo <<<'HTML'
+    <h1>What is this bot?</h1>
+    <p>If you got to this page, it's probably because you encountered an unknown User Agent with a
+    link that led you here.</p>
+    <h2><code>Mesamatrix-LinkChecker</code></h2>
+    </li>
+    <p>This bot is part of the script that updates this website. Based on the API extension names
+    (e.g. <code>VK_KHR_index_type_uint8</code>), it tries to find a URL that would link to a
+    documentation page (e.g.
+    <a href="https://docs.vulkan.org/refpages/latest/refpages/source/VK_KHR_index_type_uint8.html">https://docs.vulkan.org/refpages/latest/refpages/source/VK_KHR_index_type_uint8.html</a>).</p>
+    <p>The first time Mesamatrix is set up it tries a URL for all the extensions (~700 URLs) and
+    cache the result for 3 months (to prevent spamming). When updating, if a new API extension is
+    found, it tries just the one URL and cache the result.</p>
+HTML;
+    }
+}

--- a/src/Parser/UrlCache.php
+++ b/src/Parser/UrlCache.php
@@ -28,9 +28,13 @@ use Mesamatrix\Mesamatrix;
 class UrlCache
 {
     private const int EXPIRATION_DELAY = 7776000; // 90 * 24 * 60 * 60 = 90 days.
-    private const string RE_VALID_HTTP_RESPONSE = '/^HTTP\/[^ ]+? 2[0-9]{2}/';
+    private const string RE_VALID_HTTP_RESPONSE = '#^HTTP/\d+\.\d+\s+(\d+)#';
+    private const string USER_AGENT = 'Mesamatrix-LinkChecker/1.0 (+https://mesamatrix.net/bot.php)';
 
     private int $instanceTime;
+
+    /** @var resource */
+    private $streamContext;
 
     /** @var array<string, mixed> */
     private array $cachedUrls;
@@ -42,6 +46,16 @@ class UrlCache
     {
         $this->instanceTime = time();
         $this->cachedUrls = array();
+
+        $ctxOpts = [
+            'https' => [
+                'method' => 'HEAD',
+                'user_agent' => self::USER_AGENT,
+                'timeout' => 5,
+                'ignore_errors' => true,
+            ],
+        ];
+        $this->streamContext = stream_context_create($ctxOpts);
     }
 
     /**
@@ -116,7 +130,8 @@ class UrlCache
      */
     private function updateUrl(string $url): void
     {
-        $urlHeader = get_headers($url);
+        $urlHeader = @get_headers($url, false, $this->streamContext);
+
         $valid = false;
         if ($urlHeader !== false) {
             $response = $urlHeader[0];
@@ -124,7 +139,7 @@ class UrlCache
             if ($valid) {
                 Mesamatrix::$logger->info("URL \"{$url}\" is valid");
             } else {
-                Mesamatrix::$logger->warning("URL \"{$url}\" is invalid (reason: \"{$response}\"");
+                Mesamatrix::$logger->warning("URL \"{$url}\" is invalid (reason: \"{$response}\")");
             }
         }
 
@@ -141,6 +156,11 @@ class UrlCache
      */
     public function isValidResponse(string $response): bool
     {
-        return preg_match(self::RE_VALID_HTTP_RESPONSE, $response) !== 0;
+        if (!preg_match(self::RE_VALID_HTTP_RESPONSE, $response, $matches)) {
+            return false;
+        }
+
+        $statusCode = (int) $matches[1];
+        return $statusCode >= 200 && $statusCode < 300;
     }
 }


### PR DESCRIPTION
This PR adds a user agent when fetching the headers of the external URLs. This is to better identify the Mesamatrix script when it's crawling external websites such as khronos.org and vulkan.org. It also adds a new page to explain what the bot does.

I didn't know which string to chose as the standard seems pretty loose, so I went for `"Mesamatrix-LinkChecker/1.0 (+https://mesamatrix.net/bot.php)"`.

By defining a context to send to `get_headers()` I was able to improve the requests by defining the `HEAD` method instead of `GET` and reducing the timeout to 5 sec (instead of 60 sec)

Also closed a bracket in a string, in `UrlCache.php`.