### PR TITLE
feat: improve CSS for matrix table and github ribbon

### DIFF
--- a/config/config.default.php
+++ b/config/config.default.php
@@ -19,7 +19,7 @@ use Monolog\Level;
 return [
     "info" => [
         "log_level" => Level::Warning,
-        "version" => "3.1",
+        "version" => "3.2",
         "title" => "The Mesa drivers matrix",
         "description" => "Show Mesa progress for the OpenGL, OpenGL ES, Vulkan and OpenCL drivers implementations into an easy to read HTML page.",
         "xml_file" => "public/features.xml",

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -186,13 +186,20 @@ main p {
     max-width: 1000px;
 }
 
-.commits th                         { text-align: left; }
-.commits td                         { vertical-align: top; }
-.commits .commitsAge                {
+.commits th {
+    text-align: left;
+}
+.commits td {
+    vertical-align: top;
+}
+.commits .commitsAge {
     white-space: nowrap;
     padding-right: 1em;
 }
-.commits .commitsAge::first-letter  { text-transform: uppercase; }
+.commits .commitsAge::first-letter
+{
+    text-transform: uppercase;
+}
 
 .lb                             { font-size: 85%; border-collapse: collapse; border-spacing: 0; }
 .lb th, .lb td                  { padding: 0.25em 0.5em; }
@@ -417,14 +424,10 @@ details > summary {
     background-color: var(--donate-bg-color);
 }
 
-#github-ribbon > img {
-    position: fixed;
-    top: 0;
-    right: 0;
-    border: 0;
-}
+/**
+ * Theme switcher.
+ */
 
-/* Simple CSS for toggle switch */
 .theme-switch-wrapper {
     display: flex;
     align-items: center;
@@ -480,6 +483,21 @@ input:checked + .slider::before {
 
 .slider.round::before {
     border-radius: 50%;
+}
+
+/**
+ * GitHub ribbon.
+ */
+
+.github-fork-ribbon:before {
+    background-color: #f80;
+}
+
+#github-ribbon > img {
+    position: fixed;
+    top: 0;
+    right: 0;
+    border: 0;
 }
 
 @media screen and (max-width: 1400px) {
@@ -572,8 +590,4 @@ input:checked + .slider::before {
 .donate > form .submit {
     margin-top: 1em;
     text-align: right;
-}
-
-.github-fork-ribbon:before {
-    background-color: #f80;
 }

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -489,20 +489,16 @@ input:checked + .slider::before {
  * GitHub ribbon.
  */
 
+.github-fork-ribbon {
+    transition: opacity .1s;
+}
 .github-fork-ribbon:before {
     background-color: #f80;
 }
 
-#github-ribbon > img {
-    position: fixed;
-    top: 0;
-    right: 0;
-    border: 0;
-}
-
-@media screen and (max-width: 1400px) {
-    #github-ribbon {
-        display: none;
+@media screen and (max-width: 850px) {
+    .github-fork-ribbon {
+        opacity: 0;
     }
 }
 

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -219,12 +219,12 @@ main p {
  */
 
 details {
-    margin-top: 1em;
-    margin-bottom: 1em;
+    margin-top: 1rem;
+    margin-bottom: 1rem;
 }
 
 details > summary {
-    margin-left: 0.3em;
+    margin-left: 0.3rem;
     font-size: x-large;
     font-weight: bold;
     cursor: pointer;
@@ -311,7 +311,7 @@ details > summary {
     opacity: 0.75;
 }
 .matrix .extension > td:first-of-type {
-    min-width: 32em;
+    min-width: 25rem;
 }
 .matrix .extension > td:first-of-type.hover {
     background-color: var(--matrix-ext-hover-color);

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -235,8 +235,12 @@ details > summary {
     border: 1px solid var(--text-color);
     border-radius: 0.2em;
     padding: 0 0.5em 0.5em 0.5em;
+    margin-right: 3rem;
     overflow: auto; /* Enables both horizontal and vertical scrolling */
-    height: 90vh;
+    scrollbar-color: var(--text-color) var(--bkg-color);
+    min-width: 700px;
+    max-height: 80vh;
+    height: fit-content;
 }
 
 .matrix {


### PR DESCRIPTION
Matrix table:
* add space on the right to not overlap with the theme switcher
* change height to adapt to content
* reduce max-height to 80% of the screen (`80vh`)
* set a minimal width
* change scrollbar colors (less flashy on Chrome)

GitHub robbon:
* fade-in/out github ribbon when screen too small

