### PR TITLE
chore: force strict types

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,52 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Listen for Xdebug",
+            "type": "php",
+            "request": "launch",
+            "port": 9003,
+            "ignore": [
+                "**/vendor/**/*.php",
+                "**/CodeSniffer/**/*.php"
+            ]
+        },
+        {
+            "name": "Launch currently open script",
+            "type": "php",
+            "request": "launch",
+            "program": "${file}",
+            "cwd": "${fileDirname}",
+            "port": 0,
+            "runtimeArgs": [
+                "-dxdebug.start_with_request=yes"
+            ],
+            "env": {
+                "XDEBUG_MODE": "debug,develop",
+                "XDEBUG_CONFIG": "client_port=${port}"
+            }
+        },
+        {
+            "name": "Launch Built-in web server",
+            "type": "php",
+            "request": "launch",
+            "runtimeArgs": [
+                "-dxdebug.mode=debug",
+                "-dxdebug.start_with_request=yes",
+                "-S",
+                "localhost:0"
+            ],
+            "program": "",
+            "cwd": "${workspaceRoot}",
+            "port": 9003,
+            "serverReadyAction": {
+                "pattern": "Development Server \\(http://localhost:([0-9]+)\\) started",
+                "uriFormat": "http://localhost:%s",
+                "action": "openExternally"
+            }
+        }
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,26 @@
+{
+    "cSpell.words": [
+        "asahi",
+        "etnaviv",
+        "freedreno",
+        "GLES",
+        "GLSL",
+        "glxinfo",
+        "hasvk",
+        "Khronos",
+        "llvmpipe",
+        "Mesamatrix",
+        "panfrost",
+        "panvk",
+        "Radeon",
+        "radeonsi",
+        "radv",
+        "Rusticl",
+        "softpipe",
+        "subextension",
+        "subextensions",
+        "virgl",
+        "Vivante",
+        "zink"
+    ]
+}

--- a/config/config.default.php
+++ b/config/config.default.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 // Default configuration for Mesamatrix.
 // Values can be overwritten in a user defined config/config.php file.
 

--- a/src/Console/Application.php
+++ b/src/Console/Application.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of mesamatrix.
  *
@@ -22,6 +24,7 @@
 namespace Mesamatrix\Console;
 
 use Mesamatrix\Mesamatrix;
+use Symfony\Component\Console\Command\Command as SymfonyCommand;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\ConsoleEvents;
@@ -62,6 +65,11 @@ class Application extends \Symfony\Component\Console\Application
         parent::configureIO($input, $output);
     }
 
+    /**
+     * Gets the default commands.
+     *
+     * @return SymfonyCommand[] All the commands.
+     */
     protected function getDefaultCommands(): array
     {
         return array_merge(parent::getDefaultCommands(), array(

--- a/src/Console/Command/Fetch.php
+++ b/src/Console/Command/Fetch.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of mesamatrix.
  *

--- a/src/Console/Command/Parse.php
+++ b/src/Console/Command/Parse.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of mesamatrix.
  *
@@ -208,7 +210,7 @@ class Parse extends Command
      * @param string[] $excludedCommits The commits to exclude from the list.
      * @return Commit[]|null Array of commits.
      */
-    protected function fetchCommits($filepath, array $excludedCommits): ?array
+    protected function fetchCommits(string $filepath, array $excludedCommits): ?array
     {
         $branch = Mesamatrix::$config->getValue("git", "branch");
         $gitCommitGet = new Process(array(
@@ -324,7 +326,7 @@ class Parse extends Command
     /**
      * Take all the parsed commits and merged them to generate the final XML.
      *
-     * @param array Commit $commits The commits to merge.
+     * @param Commit[] $commits The commits to merge.
      */
     protected function generateMergedXml(array $commits): void
     {
@@ -375,7 +377,7 @@ class Parse extends Command
             $fetchHeadPath = $gitDir . '/HEAD';
         }
         $updated = filemtime($fetchHeadPath);
-        $xml->addAttribute('updated', $updated);
+        $xml->addAttribute('updated', (string) $updated);
 
         // Generate statuses.
         $statuses = $xml->addChild("statuses");
@@ -485,12 +487,18 @@ class Parse extends Command
         }
     }
 
+    /**
+     * Generates the commits log.
+     *
+     * @param SimpleXMLElement $xml The XML element.
+     * @param Commit[] $commits The commit list.
+     */
     protected function generateCommitsLog(SimpleXMLElement $xml, array $commits): void
     {
         foreach (array_reverse($commits) as $commit) {
             $commitNode = $xml->addChild("commit", htmlspecialchars($commit->getData()));
             $commitNode->addAttribute("hash", $commit->getHash());
-            $commitNode->addAttribute("timestamp", $commit->getCommitterDate()->getTimestamp());
+            $commitNode->addAttribute("timestamp", (string) ($commit->getCommitterDate()->getTimestamp()));
             $commitNode->addAttribute("subject", $commit->getSubject());
         }
     }
@@ -632,7 +640,7 @@ class Parse extends Command
         if ($commit = $ext->getModifiedAt()) {
             $modified = $mesaStatus->addChild("modified");
             $modified->addChild("commit", $commit->getHash());
-            $modified->addChild("date", $commit->getCommitterDate()->getTimestamp());
+            $modified->addChild("date", (string) ($commit->getCommitterDate()->getTimestamp()));
             $modified->addChild("author", $commit->getAuthor());
         }
 
@@ -647,7 +655,7 @@ class Parse extends Command
             if ($commit = $supportedDriver->getModifiedAt()) {
                 $modified = $xmlDriver->addChild("modified");
                 $modified->addChild("commit", $commit->getHash());
-                $modified->addChild("date", $commit->getCommitterDate()->getTimestamp());
+                $modified->addChild("date", (string) ($commit->getCommitterDate()->getTimestamp()));
                 $modified->addChild("author", $commit->getAuthor());
             }
         }

--- a/src/Console/Command/Setup.php
+++ b/src/Console/Command/Setup.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of mesamatrix.
  *

--- a/src/Controller/AboutController.php
+++ b/src/Controller/AboutController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of mesamatrix.
  *

--- a/src/Controller/ApiSubController.php
+++ b/src/Controller/ApiSubController.php
@@ -1,5 +1,7 @@
 <?php
 
+//declare(strict_types=1);
+
 /*
  * This file is part of mesamatrix.
  *
@@ -32,6 +34,8 @@ class ApiSubController
     private bool $showLbVersion;
     private ?SimpleXMLElement $xml = null;
     private ?Leaderboard $leaderboard = null;
+
+    /** @var array<string, mixed> */
     private array $matrix = array();
 
     public function __construct(string $api, bool $showLbVersion)
@@ -76,10 +80,10 @@ class ApiSubController
 
     public function createMatrixModel(SimpleXMLElement $xmlApi): void
     {
-        $this->createColumns($this->matrix, $xmlApi);
+        $this->createColumns($xmlApi);
 
         $this->matrix['sections'] = array();
-        $this->addApiSection($this->matrix, $xmlApi);
+        $this->addApiSection($xmlApi);
 
         $this->matrix['last_updated'] = (int) $this->xml['updated'];
     }
@@ -89,32 +93,32 @@ class ApiSubController
         return $this->matrix['last_updated'];
     }
 
-    private function createColumns(array &$matrix, SimpleXMLElement $xmlApi): void
+    private function createColumns(SimpleXMLElement $xmlApi): void
     {
-        $matrix['column_groups'] = array();
-        $matrix['columns'] = array();
+        $this->matrix['column_groups'] = array();
+        $this->matrix['columns'] = array();
 
         $columnIdx = 0;
 
         // Add "extension" column.
-        $matrix['column_groups'][] = array(
+        $this->matrix['column_groups'][] = array(
             'name' => '',
             'vendor_class' => 'default',
             'columns' => array($columnIdx++)
         );
-        $matrix['columns'][] = array(
+        $this->matrix['columns'][] = array(
             'name' => 'Extension',
             'type' => 'extension',
             'vendor_class' => 'default'
         );
 
         // Add "mesa" column.
-        $matrix['column_groups'][] = array(
+        $this->matrix['column_groups'][] = array(
             'name' => '',
             'vendor_class' => 'default',
             'columns' => array($columnIdx++)
         );
-        $matrix['columns'][] = array(
+        $this->matrix['columns'][] = array(
             'name' => 'mesa',
             'type' => 'driver',
             'vendor_class' => 'default'
@@ -142,11 +146,11 @@ class ApiSubController
 
         foreach ($vendors as $vendorName => $driverNames) {
             // Add separator before each vendor.
-            $matrix['column_groups'][] = array(
+            $this->matrix['column_groups'][] = array(
                 'name' => '',
                 'columns' => array($columnIdx++)
             );
-            $matrix['columns'][] = array(
+            $this->matrix['columns'][] = array(
                 'name' => '',
                 'type' => 'separator',
             );
@@ -159,18 +163,18 @@ class ApiSubController
             );
             foreach ($driverNames as $driverName) {
                 $colgroup['columns'][] = $columnIdx++;
-                $matrix['columns'][] = array(
+                $this->matrix['columns'][] = array(
                     'name' => $driverName,
                     'type' => 'driver',
                     'vendor_class' => $colgroup['vendor_class']
                 );
             }
 
-            $matrix['column_groups'][] = $colgroup;
+            $this->matrix['column_groups'][] = $colgroup;
         }
     }
 
-    private function addApiSection(array &$matrix, SimpleXMLElement $xmlApi): void
+    private function addApiSection(SimpleXMLElement $xmlApi): void
     {
         $xmlVersions = array();
         foreach ($xmlApi->versions->version as $xmlVersion) {
@@ -193,7 +197,7 @@ class ApiSubController
 
         $api = array(
             'name' => $xmlApi['name'],
-            'target' => urlencode(str_replace(' ', '', $xmlApi['name'])),
+            'target' => urlencode(str_replace(' ', '', (string) $xmlApi['name'])),
             'subsections' => array()
         );
 
@@ -201,12 +205,12 @@ class ApiSubController
             $this->addSection($api, $xmlVersion, $xmlApi->vendors);
         }
 
-        $matrix['sections'][] = $api;
+        $this->matrix['sections'][] = $api;
     }
 
     private function addSection(array &$section, SimpleXMLElement $xmlVersion, SimpleXMLElement $vendors): void
     {
-        $name = $xmlVersion['name'];
+        $name = (string) $xmlVersion['name'];
         if (!empty((string) $xmlVersion['version'])) {
             $name .= ' ' . $xmlVersion['version'];
         }
@@ -262,15 +266,15 @@ class ApiSubController
             'name' => $xmlExt['name'],
         );
 
-        $extUrlId = str_replace(' ', '_', $xmlExt['name']);
+        $extUrlId = str_replace(' ', '_', (string) $xmlExt['name']);
         $extUrlId = preg_replace('/[^A-Za-z0-9_]/', '', $extUrlId);
         $extUrlId = $subsection['target'] . '_Extension_' . $extUrlId;
         $extension['target'] = $extUrlId;
         $extension['is_subext'] = $isSubExt;
 
         if (isset($xmlExt->link)) {
-            $extension['url_href'] = $xmlExt->link['href'];
-            $extension['url_text'] = $xmlExt->link;
+            $extension['url_href'] = (string) $xmlExt->link['href'];
+            $extension['url_text'] = (string) $xmlExt->link;
         }
 
         $extTask = array();
@@ -312,7 +316,7 @@ class ApiSubController
 
     public function writeMatrix(): void
     {
-        if (array_key_exists('sections', $this->matrix) == 0) {
+        if (!array_key_exists('sections', $this->matrix)) {
             return;
         }
 
@@ -460,7 +464,11 @@ HTML;
                         if ($col['type'] === 'extension') :
                             $extNameText = $extension['name'];
                             if (isset($extension['url_text'])) :
-                                $extNameText = str_replace($extension['url_text'], '<a href="' . $extension['url_href'] . '">' . $extension['url_text'] . '</a>', $extNameText);
+                                $extNameText = str_replace(
+                                    $extension['url_text'],
+                                    '<a href="' . $extension['url_href'] . '">' . $extension['url_text'] . '</a>',
+                                    $extNameText
+                                );
                             endif;
                             $cssClass = '';
                             if ($extension['is_subext']) :

--- a/src/Controller/BaseController.php
+++ b/src/Controller/BaseController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of mesamatrix.
  *
@@ -25,14 +27,19 @@ use Mesamatrix\Mesamatrix;
 
 abstract class BaseController
 {
+    /** @var array<string, string> */
     public $pages = array(
         "Home" => ".",
         "About" => "about.php",
         "Donate?" => "donate.php");
 
-    private $pageIdx = -1;
-    private $cssScripts = [];
-    private $jsScripts = [];
+    private int $pageIdx = -1;
+
+    /** @var string[] */
+    private array $cssScripts = [];
+
+    /** @var string[] */
+    private array $jsScripts = [];
 
     public function __construct()
     {
@@ -49,7 +56,7 @@ abstract class BaseController
      * The page must be one of the page in $this->pages.
      * @param string $page The name of the page.
      */
-    final protected function setPage($page): void
+    final protected function setPage(string $page): void
     {
         $this->pageIdx = array_search($page, array_keys($this->pages));
     }
@@ -58,7 +65,7 @@ abstract class BaseController
      * Add a CSS script to include in the HTML page header.
      * @param string $script The script path.
      */
-    final public function addCssScript($script): void
+    final public function addCssScript(string $script): void
     {
         $this->cssScripts[] = $script;
     }
@@ -67,7 +74,7 @@ abstract class BaseController
      * Add a JS script to include in the HTML page header.
      * @param string $script The script path.
      */
-    final public function addJsScript($script): void
+    final public function addJsScript(string $script): void
     {
         $this->jsScripts[] = $script;
     }

--- a/src/Controller/DonateController.php
+++ b/src/Controller/DonateController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of mesamatrix.
  *
@@ -28,6 +30,7 @@ use Mesamatrix\Donation\YearContributors;
 
 class DonateController extends BaseController
 {
+    /** @var array<string, YearContributors> */
     private $yearsContributors = array();
 
     public function __construct()
@@ -44,7 +47,7 @@ class DonateController extends BaseController
      *
      * Sorted by year and by donation descending.
      */
-    private function loadContributors()
+    private function loadContributors(): void
     {
         $contribsPath = Mesamatrix::path(Mesamatrix::$config->getValue('info', 'private_dir') .
             "/contributors.json");
@@ -66,15 +69,15 @@ class DonateController extends BaseController
                 $contributor->donation = $jsonContributor->donation;
 
                 if (!array_key_exists($year, $this->yearsContributors)) {
-                    $yearContributor = new YearContributors();
-                    $yearContributor->year = $year;
-                    $this->yearsContributors[$year] = $yearContributor;
+                    $yearContributors = new YearContributors();
+                    $yearContributors->year = $year;
+                    $this->yearsContributors[$year] = $yearContributors;
                 } else {
-                    $yearContributor = $this->yearsContributors[$year];
+                    $yearContributors = $this->yearsContributors[$year];
                 }
 
-                $yearContributor->contributors[] = $contributor;
-                $yearContributor->total += $contributor->donation;
+                $yearContributors->contributors[] = $contributor;
+                $yearContributors->total += $contributor->donation;
             }
 
             // Add current year, if not there yet.

--- a/src/Controller/HomeController.php
+++ b/src/Controller/HomeController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of mesamatrix.
  *
@@ -23,12 +25,14 @@ namespace Mesamatrix\Controller;
 
 use Mesamatrix\Mesamatrix;
 use Mesamatrix\Parser\Constants;
-use Mesamatrix\Leaderboard\Leaderboard;
 use SimpleXMLElement;
 
 class HomeController extends BaseController
 {
+    /** @var array<int, array{url: string, timestamp: int, subject: string}> */
     private $commits = array();
+
+    /** @var ApiSubController[] */
     private $apiControllers = array();
 
     public function __construct()
@@ -89,16 +93,9 @@ class HomeController extends BaseController
             $this->commits[] = array(
                 'url' => Mesamatrix::$config->getValue('git', 'mesa_commit_url') . $xmlCommit['hash'],
                 'timestamp' => (int) $xmlCommit['timestamp'],
-                'subject' => $xmlCommit['subject']
+                'subject' => (string) $xmlCommit['subject']
             );
         }
-    }
-
-    private function createLeaderboard(SimpleXMLElement $xml, array $apis): Leaderboard
-    {
-        $leaderboard = new Leaderboard();
-        $leaderboard->load($xml, $apis);
-        return $leaderboard;
     }
 
     protected function writeHtmlPage(): void

--- a/src/Controller/RssController.php
+++ b/src/Controller/RssController.php
@@ -1,5 +1,26 @@
 <?php
 
+declare(strict_types=1);
+
+/*
+ * This file is part of mesamatrix.
+ *
+ * Copyright (C) 2026 Romain "Creak" Failliot.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 namespace Mesamatrix\Controller;
 
 use Mesamatrix\Mesamatrix;

--- a/src/Donation/Contributor.php
+++ b/src/Donation/Contributor.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of mesamatrix.
  *
@@ -23,7 +25,7 @@ namespace Mesamatrix\Donation;
 
 class Contributor
 {
-    public $name;
-    public $date;
-    public $donation;
+    public string $name;
+    public \DateTime $date;
+    public float $donation;
 }

--- a/src/Donation/YearContributors.php
+++ b/src/Donation/YearContributors.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of mesamatrix.
  *
@@ -23,7 +25,10 @@ namespace Mesamatrix\Donation;
 
 class YearContributors
 {
-    public $year;
+    public string $year;
+
+    /** @var Contributor[] */
     public $contributors = array();
-    public $total = 0.0;
+
+    public float $total = 0.0;
 }

--- a/src/Git/Commit.php
+++ b/src/Git/Commit.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of mesamatrix.
  *
@@ -23,32 +25,32 @@ namespace Mesamatrix\Git;
 
 class Commit
 {
-    private $filepath;
-    private $hash;
-    private $date;
-    private $author;
-    private $committer;
-    private $committerDate;
-    private $subject;
-    private $data;
+    private string $filepath;
+    private string $hash;
+    private \DateTime $date;
+    private string $author;
+    private string $committer;
+    private \DateTime $committerDate;
+    private string $subject;
+    private string $data;
 
-    public function getFilepath()
+    public function getFilepath(): string
     {
         return $this->filepath;
     }
 
-    public function setFilepath($filepath)
+    public function setFilepath(string $filepath): static
     {
         $this->filepath = $filepath;
         return $this;
     }
 
-    public function getHash()
+    public function getHash(): string
     {
         return $this->hash;
     }
 
-    public function setHash($hash)
+    public function setHash(string $hash): static
     {
         $this->hash = $hash;
         return $this;
@@ -59,12 +61,12 @@ class Commit
      *
      * @return \DateTime The commit date.
      */
-    public function getDate()
+    public function getDate(): \DateTime
     {
         return $this->date;
     }
 
-    public function setDate($date)
+    public function setDate(int|string|\DateTime $date): static
     {
         if (is_numeric($date)) {
             $this->setDateString('@' . $date);
@@ -77,40 +79,40 @@ class Commit
         return $this;
     }
 
-    public function setDateString($date, $timezone = null)
+    private function setDateString(string $date): static
     {
-        $this->setDate(new \DateTime($date, $timezone));
+        $this->date = new \DateTime($date);
         return $this;
     }
 
-    public function getAuthor()
+    public function getAuthor(): string
     {
         return $this->author;
     }
 
-    public function setAuthor($author)
+    public function setAuthor(string $author): static
     {
         $this->author = $author;
         return $this;
     }
 
-    public function getCommitter()
+    public function getCommitter(): string
     {
         return $this->committer;
     }
 
-    public function setCommitter($committer)
+    public function setCommitter(string $committer): static
     {
         $this->committer = $committer;
         return $this;
     }
 
-    public function getCommitterDate()
+    public function getCommitterDate(): \DateTime
     {
         return $this->committerDate;
     }
 
-    public function setCommitterDate($date)
+    public function setCommitterDate(string|\DateTime $date): static
     {
         if (is_numeric($date)) {
             $this->setCommitterDateString('@' . $date);
@@ -123,29 +125,29 @@ class Commit
         return $this;
     }
 
-    public function setCommitterDateString($date, $timezone = null)
+    private function setCommitterDateString(string $date): static
     {
-        $this->setCommitterDate(new \DateTime($date, $timezone));
+        $this->committerDate = new \DateTime($date);
         return $this;
     }
 
-    public function getSubject()
+    public function getSubject(): string
     {
         return $this->subject;
     }
 
-    public function setSubject($subject)
+    public function setSubject(string $subject): static
     {
         $this->subject = $subject;
         return $this;
     }
 
-    public function getData()
+    public function getData(): string
     {
         return $this->data;
     }
 
-    public function setData($data)
+    public function setData(string $data): static
     {
         $this->data = $data;
         return $this;

--- a/src/Git/Process.php
+++ b/src/Git/Process.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of mesamatrix.
  *
@@ -26,6 +28,9 @@ use Mesamatrix\Mesamatrix;
 
 class Process extends \Symfony\Component\Process\Process
 {
+    /**
+     * @param string[] $arguments The list of arguments.
+     */
     public function __construct(array $arguments = array())
     {
         // Replace '@gitDir@' by Mesa Git directory.

--- a/src/Hints.php
+++ b/src/Hints.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of mesamatrix.
  *
@@ -23,6 +25,9 @@ namespace Mesamatrix;
 
 class Hints
 {
+    /** @var string[] */
+    private array $list;
+
     public function __construct()
     {
         $this->list = array();
@@ -64,6 +69,4 @@ class Hints
     {
         return $this->list[$idx];
     }
-
-    private $list;
 }

--- a/src/Leaderboard/LbApiVersion.php
+++ b/src/Leaderboard/LbApiVersion.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of mesamatrix.
  *
@@ -27,7 +29,8 @@ class LbApiVersion
     private string $name;
     private string $version;
     private int $numExts;
-    private array $drivers;
+
+    /** @var array<string, LbDriverScore> */
     private array $driverScores;
 
     /**
@@ -35,7 +38,7 @@ class LbApiVersion
      *
      * @param string $name API name (e.g. OpenGL, Vulkan, ...).
      * @param string $version API version (e.g. 4.5, 1.1, ...).
-     * @param integer $numExts Total number of extensions.
+     * @param int $numExts Total number of extensions.
      * @remark Versions are identified by `id` which is the concatenation of
      *         the name and the version (examples: OpenGL4.5, Vulkan1.1, ...).
      */
@@ -45,13 +48,12 @@ class LbApiVersion
         $this->name = $name;
         $this->version = $version;
         $this->numExts = $numExts;
-        $this->drivers = array();
     }
 
     /**
      * Get the API ID for this version.
      */
-    public function getId()
+    public function getId(): string
     {
         return $this->id;
     }
@@ -59,7 +61,7 @@ class LbApiVersion
     /**
      * Get the API name.
      */
-    public function getName()
+    public function getName(): string
     {
         return $this->name;
     }
@@ -67,7 +69,7 @@ class LbApiVersion
     /**
      * Get the API version.
      */
-    public function getVersion()
+    public function getVersion(): string
     {
         return $this->version;
     }
@@ -75,24 +77,24 @@ class LbApiVersion
     /**
      * Replace or add a new driver and set it's number of extensions done.
      *
-     * @param string $drivername Name of the driver.
-     * @param integer $numExtsDone Number of extensions done.
+     * @param string $driverName Name of the driver.
+     * @param int $numExtsDone Number of extensions done.
      */
-    public function addDriver(string $drivername, int $numExtsDone)
+    public function addDriver(string $driverName, int $numExtsDone): void
     {
-        $this->driverScores[$drivername] = new LbDriverScore(
+        $this->driverScores[$driverName] = new LbDriverScore(
             $numExtsDone,
             $this->getNumExts(),
-            (float) $this->getVersion()
+            $this->getVersion()
         );
     }
 
     /**
      * Set the number of extensions for this API version.
      *
-     * @param integer $num Number of extensions.
+     * @param int $num Number of extensions.
      */
-    public function setNumExts($num)
+    public function setNumExts(int $num): void
     {
         $this->numExts = $num;
     }
@@ -100,7 +102,7 @@ class LbApiVersion
     /**
      * Get the number of extensions for this API version.
      */
-    public function getNumExts()
+    public function getNumExts(): int
     {
         return $this->numExts;
     }
@@ -108,21 +110,21 @@ class LbApiVersion
     /**
      * Get the number of extension done for a given driver.
      *
-     * @param string $drivername Name of the driver.
+     * @param string $driverName Name of the driver.
      * @return LbDriverScore The driver score.
      */
-    public function getDriverScore($drivername)
+    public function getDriverScore($driverName): LbDriverScore
     {
-        return $this->driverScores[$drivername];
+        return $this->driverScores[$driverName];
     }
 
     /**
      * Get all the drivers scores for this API version.
      *
-     * @return mixed[] An associative array: the key is the driver name, the
-     *                 value is an LbDriverScore.
+     * @return LbDriverScore[] An associative array: the key is the driver name, the
+     *                         value is an LbDriverScore.
      */
-    public function getDriverScores()
+    public function getDriverScores(): array
     {
         return $this->driverScores;
     }

--- a/src/Leaderboard/LbDriverScore.php
+++ b/src/Leaderboard/LbDriverScore.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of mesamatrix.
  *
@@ -23,18 +25,18 @@ namespace Mesamatrix\Leaderboard;
 
 class LbDriverScore
 {
-    private $numExtsDone;
-    private $numExts;
-    private $apiVersion;
+    private int $numExtsDone;
+    private int $numExts;
+    private ?string $apiVersion;
 
     /**
      * LbDriver constructor.
      *
      * @param int $numExtsDone Number of extensions done.
      * @param int $numExts Total number of extensions.
-     * @param float $apiVersion API version (e.g. 3.1, 4.0).
+     * @param string|null $apiVersion API version (e.g. 3.1, 4.0).
      */
-    public function __construct(int $numExtsDone, int $numExts, float $apiVersion)
+    public function __construct(int $numExtsDone, int $numExts, ?string $apiVersion)
     {
         $this->setNumExtensionsDone($numExtsDone);
         $this->setNumExtensions($numExts);
@@ -44,7 +46,7 @@ class LbDriverScore
     /**
      * Set the number of extensions done.
      */
-    public function setNumExtensionsDone($num)
+    public function setNumExtensionsDone(int $num): void
     {
         $this->numExtsDone = $num;
     }
@@ -52,7 +54,7 @@ class LbDriverScore
     /**
      * Get the number of extensions done.
      */
-    public function getNumExtensionsDone()
+    public function getNumExtensionsDone(): int
     {
         return $this->numExtsDone;
     }
@@ -60,7 +62,7 @@ class LbDriverScore
     /**
      * Set the total number of extensions.
      */
-    public function setNumExtensions($num)
+    public function setNumExtensions(int $num): void
     {
         $this->numExts = $num;
     }
@@ -68,7 +70,7 @@ class LbDriverScore
     /**
      * Get the total number of extensions.
      */
-    public function getNumExtensions()
+    public function getNumExtensions(): int
     {
         return $this->numExts;
     }
@@ -76,7 +78,7 @@ class LbDriverScore
     /**
      * Get the score.
      */
-    public function getScore()
+    public function getScore(): float
     {
         return $this->numExts !== 0 ? $this->numExtsDone / $this->numExts : 0;
     }
@@ -84,7 +86,7 @@ class LbDriverScore
     /**
      * Set the API version.
      */
-    public function setApiVersion($apiVersion)
+    public function setApiVersion(?string $apiVersion)
     {
         $this->apiVersion = $apiVersion;
     }
@@ -92,7 +94,7 @@ class LbDriverScore
     /**
      * Get the API version.
      */
-    public function getApiVersion()
+    public function getApiVersion(): ?string
     {
         return $this->apiVersion;
     }

--- a/src/Leaderboard/Leaderboard.php
+++ b/src/Leaderboard/Leaderboard.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of mesamatrix.
  *
@@ -25,7 +27,9 @@ use Mesamatrix\Parser\Constants;
 
 class Leaderboard
 {
+    /** @var LbApiVersion[] */
     private array $apiVersions;
+
     private bool $useVersions;
 
     /**
@@ -40,9 +44,9 @@ class Leaderboard
     /**
      * Load leaderboard from data.
      *
-     * @param SimpleXMLElement $xmlApi The XML element of the API.
+     * @param \SimpleXMLElement $xmlApi The XML element of the API.
      */
-    public function load(\SimpleXMLElement $xmlApi)
+    public function load(\SimpleXMLElement $xmlApi): void
     {
         $this->loadApi($xmlApi);
 
@@ -71,9 +75,9 @@ class Leaderboard
     /**
      * Load all the versions from a given API.
      *
-     * @param SimpleXMLElement $xmlApi The XML tag for the wanted API.
+     * @param \SimpleXMLElement $xmlApi The XML tag for the wanted API.
      */
-    private function loadApi(\SimpleXMLElement $xmlApi)
+    private function loadApi(\SimpleXMLElement $xmlApi): void
     {
         foreach ($xmlApi->versions->version as $xmlVersion) {
             // Count total extensions and sub-extensions.
@@ -144,9 +148,9 @@ class Leaderboard
      * Find the leaderboard for a specific API version.
      *
      * @param string $id API ID (format example: OpenGL4.5, Vulkan1.1, ...).
-     * @return LbApiVersion The leaderboard for the given API version.
+     * @return LbApiVersion|null The leaderboard for the given API version.
      */
-    public function findApiVersion($id)
+    public function findApiVersion(string $id): ?LbApiVersion
     {
         $i = 0;
         $numApiVersions = count($this->apiVersions);
@@ -160,7 +164,7 @@ class Leaderboard
     /**
      * Get the total number of extensions.
      */
-    public function getNumTotalExts()
+    public function getNumTotalExts(): int
     {
         $numExts = 0;
         foreach ($this->apiVersions as &$apiVersion) {
@@ -178,28 +182,28 @@ class Leaderboard
      * @return LbDriverScore[] An associative array: the key is the driver name, the
      *                         value is an LbDriverScore.
      */
-    public function getDriversSortedByExtsDone(string $api)
+    public function getDriversSortedByExtsDone(string $api): array
     {
         $sortedDriversScores = array();
         $numTotalExts = $this->getNumTotalExts();
         foreach ($this->apiVersions as &$apiVersion) {
             $apiVersionDrivers = $apiVersion->getDriverScores();
-            foreach ($apiVersionDrivers as $drivername => $driverScore) {
-                if (!array_key_exists($drivername, $sortedDriversScores)) {
+            foreach ($apiVersionDrivers as $driverName => $driverScore) {
+                if (!array_key_exists($driverName, $sortedDriversScores)) {
                     // Add new driver.
-                    $sortedDriversScores[$drivername] = new LbDriverScore(0, $numTotalExts, 0);
+                    $sortedDriversScores[$driverName] = new LbDriverScore(0, $numTotalExts, null);
                 }
 
                 // Add up the number of extensions done for this driver.
-                $numExtsDone = $sortedDriversScores[$drivername]->getNumExtensionsDone() +
+                $numExtsDone = $sortedDriversScores[$driverName]->getNumExtensionsDone() +
                     $driverScore->getNumExtensionsDone();
-                $sortedDriversScores[$drivername]->setNumExtensionsDone($numExtsDone);
+                $sortedDriversScores[$driverName]->setNumExtensionsDone($numExtsDone);
             }
         }
 
         // Keep last max API version fully implemented.
-        foreach (array_keys($sortedDriversScores) as $drivername) {
-            $sortedDriversScores[$drivername]->setApiVersion($this->getDriverApiVersion($api, $drivername));
+        foreach (array_keys($sortedDriversScores) as $driverName) {
+            $sortedDriversScores[$driverName]->setApiVersion($this->getDriverApiVersion($api, $driverName));
         }
 
         // Sort by number of extensions and then by API version.
@@ -222,10 +226,10 @@ class Leaderboard
      * Get latest valid API version for a driver.
      *
      * @param string $api Name of the API (OpenGL, OpenGL ES, Vulkan, ...).
-     * @param string $drivername Name of the driver (mesa, r600, ...).
-     * @return string The API version string; NULL otherwise.
+     * @param string $driverName Name of the driver (mesa, r600, ...).
+     * @return string|null The API version string; NULL otherwise.
      */
-    public function getDriverApiVersion(string $api, string $drivername)
+    public function getDriverApiVersion(string $api, string $driverName): ?string
     {
         $apiVersionNbr = null;
 
@@ -236,7 +240,7 @@ class Leaderboard
         while ($i > 0) {
             $apiVersion = $this->apiVersions[--$i];
             if ($apiVersion->getName() === $api) {
-                if ($apiVersion->getDriverScore($drivername)->getNumExtensionsDone() !== $apiVersion->getNumExts()) {
+                if ($apiVersion->getDriverScore($driverName)->getNumExtensionsDone() !== $apiVersion->getNumExts()) {
                     break;
                 }
 
@@ -255,7 +259,7 @@ class Leaderboard
      * @param integer $numExts Total number of extensions.
      * @return LbApiVersion The new item.
      */
-    private function createApiVersion(string $name, string $version, int $numExts)
+    private function createApiVersion(string $name, string $version, int $numExts): LbApiVersion
     {
         $apiVersion = new LbApiVersion($name, $version, $numExts);
         $this->apiVersions[] = $apiVersion;

--- a/src/Mesamatrix.php
+++ b/src/Mesamatrix.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of mesamatrix.
  *
@@ -34,7 +36,7 @@ class Mesamatrix
     public static Config $config;
     public static Logger $logger;
 
-    public static function init()
+    public static function init(): void
     {
         date_default_timezone_set('UTC');
 
@@ -83,11 +85,11 @@ class Mesamatrix
         self::$logger->debug('Base initialization complete');
 
         self::$logger->debug('Log level: ' . Logger::toMonologLevel($logLevel)->getName());
-        self::$logger->debug('PHP error_reporting: 0x' . dechex(ini_get('error_reporting')));
+        self::$logger->debug('PHP error_reporting: 0x' . dechex((int) ini_get('error_reporting')));
         self::$logger->debug('PHP display_errors: ' . ini_get('display_errors'));
     }
 
-    public static function path($path)
+    public static function path(string $path): string
     {
         return self::$serverRoot . DIRECTORY_SEPARATOR . $path;
     }

--- a/src/Parser/ApiVersion.php
+++ b/src/Parser/ApiVersion.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of mesamatrix.
  *
@@ -21,8 +23,6 @@
 
 namespace Mesamatrix\Parser;
 
-use Mesamatrix\Mesamatrix;
-
 class ApiVersion
 {
     public function __construct(
@@ -41,41 +41,41 @@ class ApiVersion
     }
 
     // API name
-    public function setName(string $name)
+    public function setName(string $name): void
     {
         $this->name = $name;
     }
-    public function getName()
+    public function getName(): string
     {
         return $this->name;
     }
 
     // API version
-    public function setVersion(?string $version)
+    public function setVersion(?string $version): void
     {
         $this->version = $version;
     }
-    public function getVersion()
+    public function getVersion(): ?string
     {
         return $this->version;
     }
 
     // GLSL name
-    public function setGlslName(?string $name)
+    public function setGlslName(?string $name): void
     {
         $this->glslName = $name;
     }
-    public function getGlslName()
+    public function getGlslName(): ?string
     {
         return $this->glslName;
     }
 
     // GLSL version
-    public function setGlslVersion(?string $version)
+    public function setGlslVersion(?string $version): void
     {
         $this->glslVersion = $version;
     }
-    public function getGlslVersion()
+    public function getGlslVersion(): ?string
     {
         return $this->glslVersion;
     }
@@ -85,7 +85,7 @@ class ApiVersion
      *
      * @param Extension $extension The extension to add.
      */
-    public function addExtension(Extension $extension)
+    public function addExtension(Extension $extension): void
     {
         $this->extensions[] = $extension;
     }
@@ -93,9 +93,9 @@ class ApiVersion
     /**
      * Get all the drivers for this API.
      *
-     * @return string[] The list of supported drivers names; null if API not recognized.
+     * @return string[]|null The list of supported drivers names; null if API not recognized.
      */
-    public function getAllApiDrivers()
+    public function getAllApiDrivers(): ?array
     {
         $apiName = $this->getName();
         switch ($apiName) {
@@ -123,7 +123,7 @@ class ApiVersion
      *
      * @return string[] The list of supported drivers names.
      */
-    public function getSupportedDrivers()
+    public function getSupportedDrivers(): array
     {
         $supportedDrivers = [];
 
@@ -150,14 +150,14 @@ class ApiVersion
      *
      * @param Matrix $matrix The entire matrix.
      */
-    public function solveExtensionDependencies($matrix)
+    public function solveExtensionDependencies(Matrix $matrix): void
     {
         foreach ($this->getExtensions() as $ext) {
             $ext->solveExtensionDependencies($matrix);
         }
     }
 
-    public function loadXml(\SimpleXMLElement $xmlSection)
+    public function loadXml(\SimpleXMLElement $xmlSection): void
     {
         $xmlExts = $xmlSection->extensions->extension;
 
@@ -199,7 +199,7 @@ class ApiVersion
      *
      * @return Extension[] All the extensions.
      */
-    public function getExtensions()
+    public function getExtensions(): array
     {
         return $this->extensions;
     }
@@ -209,7 +209,7 @@ class ApiVersion
      *
      * @return int The number of extensions.
      */
-    public function getNumExtensions()
+    public function getNumExtensions(): int
     {
         return count($this->extensions);
     }
@@ -219,9 +219,9 @@ class ApiVersion
      *
      * @param string $name The name of the extension to find.
      *
-     * @return Extension The extension or null if not found.
+     * @return Extension|null The extension or null if not found.
      */
-    public function getExtensionByName($name)
+    public function getExtensionByName(string $name): ?Extension
     {
         foreach ($this->extensions as $extension) {
             if ($extension->getName() === $name) {
@@ -234,11 +234,11 @@ class ApiVersion
     /**
      * Find the extensions with the given substring.
      *
-     * @param string $str The substring to find in the extension name.
+     * @param string $substr The substring to find in the extension name.
      *
-     * @return Extension The extension or null if not found.
+     * @return Extension|null The extension or null if not found.
      */
-    public function getExtensionBySubstr($substr)
+    public function getExtensionBySubstr(string $substr): ?Extension
     {
         foreach ($this->extensions as $extension) {
             if (strstr($extension->getName(), $substr) !== false) {
@@ -253,5 +253,7 @@ class ApiVersion
     private ?string $glslName;
     private ?string $glslVersion;
     private Hints $hints;
+
+    /** @var Extension[] */
     private array $extensions;
 }

--- a/src/Parser/Constants.php
+++ b/src/Parser/Constants.php
@@ -143,6 +143,6 @@ abstract class Constants
     // 3: dependency match index
     public const RE_DEP_DRIVERS_HINTS = [
         [ '/^all drivers that support (GL_[_[:alnum:]]+)$/i', true, DependsOn::EXTENSION, 1 ],
-        [ '/^all drivers that support GLES ?(\d+\.\d+\+?)?$/i', true, DependsOn::GLES_VERSION, 1 ],
+        [ '/^all drivers that support GLES (\d+\.\d+)?\+?$/i', true, DependsOn::GLES_VERSION, 1 ],
     ];
 }

--- a/src/Parser/DependsOn.php
+++ b/src/Parser/DependsOn.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of mesamatrix.
  *
@@ -26,6 +28,6 @@ namespace Mesamatrix\Parser;
  */
 abstract class DependsOn
 {
-    public const EXTENSION = 0;
-    public const GLES_VERSION = 1;
+    public const int EXTENSION = 0;
+    public const int GLES_VERSION = 1;
 }

--- a/src/Parser/Extension.php
+++ b/src/Parser/Extension.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of mesamatrix.
  *
@@ -22,10 +24,22 @@
 namespace Mesamatrix\Parser;
 
 use Mesamatrix\Git\Commit;
-use Mesamatrix\Mesamatrix;
 
 class Extension
 {
+    private string $name;
+    private string $status;
+    private Hints $hints;
+    private int $hintIdx;
+
+    /** @var SupportedDriver[] */
+    private array $supportedDrivers;
+
+    private ?Commit $modifiedAt;
+
+    /** @var Extension[] */
+    private array $subextensions;
+
     /**
      * Extension constructor.
      *
@@ -73,7 +87,7 @@ class Extension
      *
      * @return string[] An array of two string; 0: the driver name, 1: its hint.
      */
-    private static function splitDriverNameAndHint($driverNameAndHint, array $apiDrivers)
+    private static function splitDriverNameAndHint($driverNameAndHint, array $apiDrivers): array
     {
         $driverName = null;
         $driverHint = "";
@@ -94,35 +108,35 @@ class Extension
     }
 
     // name
-    public function setName($name)
+    public function setName(string $name): void
     {
         $this->name = $name;
     }
-    public function getName()
+    public function getName(): string
     {
         return $this->name;
     }
 
     // status
-    public function setStatus($status)
+    public function setStatus(string $status): void
     {
         $this->status = $status;
     }
-    public function getStatus()
+    public function getStatus(): string
     {
         return $this->status;
     }
 
     // hint
-    public function setHint($hint)
+    public function setHint(string $hint): void
     {
         $this->hintIdx = $this->hints->addToHints($hint);
     }
-    public function getHintIdx()
+    public function getHintIdx(): int
     {
         return $this->hintIdx;
     }
-    public function getHint()
+    public function getHint(): ?string
     {
         if ($this->hintIdx === -1) {
             return null;
@@ -132,18 +146,25 @@ class Extension
     }
 
     // supported drivers
-    public function addSupportedDriver(SupportedDriver $driver)
+    public function addSupportedDriver(SupportedDriver $driver): void
     {
         $existingDriver = $this->getSupportedDriverByName($driver->getName());
         if ($existingDriver === null) {
             $this->supportedDrivers[] = $driver;
         }
     }
-    public function getSupportedDrivers()
+
+    /**
+     * Gets all the supported drivers
+     *
+     * @return SupportedDriver[] The supported drivers.
+     */
+    public function getSupportedDrivers(): array
     {
         return $this->supportedDrivers;
     }
-    public function getSupportedDriverByName($driverName)
+
+    public function getSupportedDriverByName(string $driverName): ?SupportedDriver
     {
         foreach ($this->supportedDrivers as $supportedDriver) {
             $matchName = $supportedDriver->getName();
@@ -156,11 +177,11 @@ class Extension
     }
 
     // modified at
-    public function setModifiedAt(?Commit $commit)
+    public function setModifiedAt(?Commit $commit): void
     {
         $this->modifiedAt = $commit;
     }
-    public function getModifiedAt()
+    public function getModifiedAt(): ?Commit
     {
         return $this->modifiedAt;
     }
@@ -170,7 +191,7 @@ class Extension
      *
      * @param Extension $extension The extension to add.
      */
-    public function addSubExtension(Extension $extension)
+    public function addSubExtension(Extension $extension): void
     {
         $this->subextensions[] = $extension;
     }
@@ -180,7 +201,7 @@ class Extension
      *
      * @param Matrix $matrix The entire matrix.
      */
-    public function solveExtensionDependencies($matrix)
+    public function solveExtensionDependencies(Matrix $matrix): void
     {
         $hint = $this->getHint();
         if ($hint === null) {
@@ -188,10 +209,14 @@ class Extension
         }
 
         foreach (Constants::RE_DEP_DRIVERS_HINTS as $reDepDriversHint) {
-            if (preg_match($reDepDriversHint[0], $hint, $matches) === 1) {
-                switch ($reDepDriversHint[2]) {
+            $re = $reDepDriversHint[0];
+            $setHint = $reDepDriversHint[1];
+            $dependsOn = $reDepDriversHint[2];
+            $matchIdx = $reDepDriversHint[3];
+            if (preg_match($re, $hint, $matches) === 1) {
+                switch ($dependsOn) {
                     case DependsOn::EXTENSION:
-                        $depExt = $matrix->getExtensionBySubstr($matches[$reDepDriversHint[3]]);
+                        $depExt = $matrix->getExtensionBySubstr($matches[$matchIdx]);
                         if ($depExt !== null) {
                             foreach ($depExt->supportedDrivers as $supportedDriver) {
                                 $this->addSupportedDriver($supportedDriver);
@@ -200,11 +225,11 @@ class Extension
                         break;
 
                     case DependsOn::GLES_VERSION:
-                        $supportedDriverNames = $matrix->getDriversSupportingGlesVersion($matches[$reDepDriversHint[3]]);
+                        $supportedDriverNames = $matrix->getDriversSupportingGlesVersion($matches[$matchIdx]);
                         if ($supportedDriverNames !== null) {
                             foreach ($supportedDriverNames as $supportedDriverName) {
                                 $supportedDriver = new SupportedDriver($supportedDriverName, $this->hints);
-                                if ($reDepDriversHint[2]) {
+                                if ($setHint) {
                                     $supportedDriver->setHint($hint);
                                 }
 
@@ -217,7 +242,7 @@ class Extension
         }
     }
 
-    public function loadXml(\SimpleXMLElement $xmlExt)
+    public function loadXml(\SimpleXMLElement $xmlExt): void
     {
         $xmlSubExts = $xmlExt->xpath('./subextensions/subextension');
 
@@ -249,7 +274,7 @@ class Extension
      *
      * @return Extension[] All the sub-extensions.
      */
-    public function getSubExtensions()
+    public function getSubExtensions(): array
     {
         return $this->subextensions;
     }
@@ -259,9 +284,9 @@ class Extension
      *
      * @param string $name The name of the extension to find.
      *
-     * @return Extension The extension or null if not found.
+     * @return Extension|null The extension or null if not found.
      */
-    public function findSubExtensionByName($name)
+    public function findSubExtensionByName($name): ?Extension
     {
         foreach ($this->subextensions as $subext) {
             if ($subext->getName() === $name) {
@@ -271,12 +296,4 @@ class Extension
 
         return null;
     }
-
-    private string $name;
-    private string $status;
-    private Hints $hints;
-    private int $hintIdx;
-    private array $supportedDrivers;
-    private ?Commit $modifiedAt;
-    private array $subextensions;
 }

--- a/src/Parser/Hints.php
+++ b/src/Parser/Hints.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of mesamatrix.
  *
@@ -24,9 +26,10 @@ namespace Mesamatrix\Parser;
 // Hints gathered during the parsing.
 class Hints
 {
-    public $allHints = array();
+    /** @var string[] */
+    public array $allHints = array();
 
-    public function addToHints($hint)
+    public function addToHints(string $hint): int
     {
         $idx = -1;
         if (!empty($hint)) {

--- a/src/Parser/Matrix.php
+++ b/src/Parser/Matrix.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of mesamatrix.
  *
@@ -25,7 +27,9 @@ use SimpleXMLElement;
 
 class Matrix
 {
+    /** @var ApiVersion[] */
     private array $apiVersions;
+
     private Hints $hints;
 
     public function __construct()
@@ -55,7 +59,7 @@ class Matrix
      * @param string $name The API name.
      * @param string|null $version The API version.
      *
-     * @return ApiVersion The API version is found; NULL otherwise.
+     * @return ApiVersion|null The API version is found; NULL otherwise.
      */
     public function getApiVersionByName(string $name, ?string $version): ?ApiVersion
     {
@@ -75,7 +79,7 @@ class Matrix
      *
      * @param string $substr The substring to find.
      *
-     * @return Extension The extension if found; NULL otherwise.
+     * @return Extension|null The extension if found; NULL otherwise.
      */
     public function getExtensionBySubstr(string $substr): ?Extension
     {
@@ -94,8 +98,8 @@ class Matrix
      *
      * @param string $version The GL ES version to look for.
      *
-     * @return string[] The list of drivers that supports
-     *         the OpenGL ES; NULL otherwise.
+     * @return string[]|null The list of drivers that supports the OpenGL ES;
+     *                       NULL otherwise.
      */
     public function getDriversSupportingGlesVersion(string $version): ?array
     {

--- a/src/Parser/Parser.php
+++ b/src/Parser/Parser.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of mesamatrix.
  *
@@ -25,7 +27,7 @@ use Mesamatrix\Mesamatrix;
 
 class Parser
 {
-    public function parseFile($filename): Matrix
+    public function parseFile(string $filename): ?Matrix
     {
         $handle = fopen($filename, "r");
         if ($handle === false) {
@@ -52,7 +54,7 @@ class Parser
     /**
      * Parse a stream of features.txt.
      *
-     * @param $handle The stream handle.
+     * @param resource $handle The stream handle.
      * @return Matrix The matrix.
      */
     public function parseStream($handle): Matrix
@@ -176,17 +178,17 @@ class Parser
      *
      * @param ApiVersion $apiVersion The version section to feed during parsing.
      * @param Matrix $matrix The matrix to feed during parsing.
-     * @param $handle The file handle.
-     * @param array() $allSupportedDrivers Drivers that already support all the extension in the section.
+     * @param resource $handle The file handle.
+     * @param string[] $allSupportedDrivers Drivers that already support all the extension in the section.
      *
-     * @return The next line unparsed.
+     * @return string The next line unparsed.
      */
     private function parseSection(
         ApiVersion $apiVersion,
         Matrix $matrix,
         $handle,
-        $allSupportedDrivers = array()
-    ) {
+        array $allSupportedDrivers = array()
+    ): string {
         $line = $this->skipEmptyLines(fgets($handle), $handle);
 
         // Verify the line is indented.
@@ -310,7 +312,13 @@ class Parser
         return $line;
     }
 
-    private function skipEmptyLines($curLine, $handle)
+    /**
+     * Skips empty lines.
+     *
+     * @param string|bool $curLine The current line.
+     * @param resource $handle The file handle.
+     */
+    private function skipEmptyLines(string|bool $curLine, $handle): string|false
     {
         while ($curLine !== false && $curLine === "\n") {
             $curLine = fgets($handle);
@@ -342,6 +350,14 @@ class Parser
         return null;
     }
 
+    /**
+     * Merges the drivers.
+     *
+     * @param string[] $dst The base array of drivers.
+     * @param string[] $src The array to merge into $dst.
+     *
+     * @return string[] The $dst parameter.
+     */
     private function mergeDrivers(array &$dst, array $src): array
     {
         foreach ($src as $srcDriver) {
@@ -369,12 +385,12 @@ class Parser
     /**
      * Parse the hint and extract the drivers from it.
      *
-     * @param string $hint The hint to test.
-     * @param string $useHint[out] Hint to use; null otherwise.
+     * @param string $hintStr The hint to test.
+     * @param-out string|null $useHint Hint to use; null otherwise.
      *
-     * @return array|null The drivers list, or null.
+     * @return string[]|null The drivers list, or null.
      */
-    private function getDriversFromHint($hintStr, &$useHint): ?array
+    private function getDriversFromHint(string $hintStr, string|null &$useHint): ?array
     {
         if (empty($hintStr)) {
             return null;
@@ -384,8 +400,10 @@ class Parser
 
         // Is the hint saying it's supporting all drivers?
         foreach (Constants::RE_ALL_DRIVERS_HINTS as $reAllDriversHint) {
-            if (preg_match($reAllDriversHint[0], $hintStr) === 1) {
-                if ($reAllDriversHint[1] === true) {
+            $re = $reAllDriversHint[0];
+            $setHint = $reAllDriversHint[1];
+            if (preg_match($re, $hintStr) === 1) {
+                if ($setHint === true) {
                     $useHint = $hintStr;
                 }
 
@@ -402,8 +420,10 @@ class Parser
             } else {
                 // Is the hint saying it depends on something else?
                 foreach (Constants::RE_DEP_DRIVERS_HINTS as $reDepDriversHint) {
-                    if (preg_match($reDepDriversHint[0], $hintItem) === 1) {
-                        if ($reAllDriversHint[1] === true) {
+                    $re = $reDepDriversHint[0];
+                    $setHint = $reDepDriversHint[1];
+                    if (preg_match($re, $hintItem) === 1) {
+                        if ($setHint === true) {
                             if ($useHint !== null) {
                                 Mesamatrix::$logger->warning('Unhandled situation: more than one extension dependency');
                             }
@@ -418,20 +438,22 @@ class Parser
         return !empty($drivers) ? $drivers : null;
     }
 
-    private $reExtension = "";
-    private $apiDrivers = null;
+    private string $reExtension = "";
 
-    private const OTHER_OFFICIAL_GL_EXTENSIONS =
+    /** @var string[]|null */
+    private ?array $apiDrivers = null;
+
+    private const string OTHER_OFFICIAL_GL_EXTENSIONS =
         "Khronos, ARB, and OES extensions that are not part of any OpenGL or OpenGL ES version:\n";
-    private const OTHER_OFFICIAL_VK_EXTENSIONS =
+    private const string OTHER_OFFICIAL_VK_EXTENSIONS =
         "Khronos extensions that are not part of any Vulkan version:\n";
-    private const RUSTICL_OPENCL_CORE_OPTIONAL =
+    private const string RUSTICL_OPENCL_CORE_OPTIONAL =
         "Rusticl Optional Core Features:\n";
-    private const RUSTICL_OPENCL_CL2_OPTIONAL =
+    private const string RUSTICL_OPENCL_CL2_OPTIONAL =
         "Rusticl Optional OpenCL 2.x Features:\n";
-    private const RUSTICL_OPENCL_EXTENSIONS =
+    private const string RUSTICL_OPENCL_EXTENSIONS =
         "Rusticl extensions:\n";
 
-    private const RE_ALL_DONE = "/ -+ all DONE: (.*)/i";
-    private const RE_NOTE = "/^(\(.+\)) (.*)$/";
+    private const string RE_ALL_DONE = "/ -+ all DONE: (.*)/i";
+    private const string RE_NOTE = "/^(\(.+\)) (.*)$/";
 }

--- a/src/Parser/SupportedDriver.php
+++ b/src/Parser/SupportedDriver.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of mesamatrix.
  *
@@ -25,7 +27,12 @@ use Mesamatrix\Git\Commit;
 
 class SupportedDriver
 {
-    public function __construct($name, $hints)
+    private string $name;
+    private Hints $hints;
+    private int $hintIdx;
+    private ?Commit $modifiedAt;
+
+    public function __construct(string $name, Hints $hints)
     {
         $this->name = $name;
         $this->hints = $hints;
@@ -34,25 +41,25 @@ class SupportedDriver
     }
 
     // name
-    public function setName($name)
+    public function setName(string $name): void
     {
         $this->name = $name;
     }
-    public function getName()
+    public function getName(): string
     {
         return $this->name;
     }
 
     // hints
-    public function setHint($hint)
+    public function setHint(string $hint): void
     {
         $this->hintIdx = $this->hints->addToHints($hint);
     }
-    public function getHintIdx()
+    public function getHintIdx(): int
     {
         return $this->hintIdx;
     }
-    public function getHint()
+    public function getHint(): ?string
     {
         if ($this->hintIdx === -1) {
             return null;
@@ -62,17 +69,12 @@ class SupportedDriver
     }
 
     // modified at
-    public function setModifiedAt($commit)
+    public function setModifiedAt(?Commit $commit): void
     {
         $this->modifiedAt = $commit;
     }
-    public function getModifiedAt()
+    public function getModifiedAt(): ?Commit
     {
         return $this->modifiedAt;
     }
-
-    private $name;
-    private $hints;
-    private $hintIdx;
-    private $modifiedAt;
 }

--- a/src/Parser/UrlCache.php
+++ b/src/Parser/UrlCache.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of mesamatrix.
  *
@@ -25,8 +27,13 @@ use Mesamatrix\Mesamatrix;
 
 class UrlCache
 {
-    private const EXPIRATION_DELAY = 7776000; // 90 * 24 * 60 * 60 = 90 days.
-    private const RE_VALID_HTTP_RESPONSE = '/^HTTP\/[^ ]+? 2[0-9]{2}/';
+    private const int EXPIRATION_DELAY = 7776000; // 90 * 24 * 60 * 60 = 90 days.
+    private const string RE_VALID_HTTP_RESPONSE = '/^HTTP\/[^ ]+? 2[0-9]{2}/';
+
+    private int $instanceTime;
+
+    /** @var array<string, mixed> */
+    private array $cachedUrls;
 
     /**
      * Default constructor.
@@ -136,7 +143,4 @@ class UrlCache
     {
         return preg_match(self::RE_VALID_HTTP_RESPONSE, $response) !== 0;
     }
-
-    private $instanceTime;
-    private $cachedUrls;
 }

--- a/src/base.php
+++ b/src/base.php
@@ -1,6 +1,6 @@
 <?php
 
-//declare(strict_types=1);
+declare(strict_types=1);
 
 /*
  * This file is part of mesamatrix.


### PR DESCRIPTION
This PR forces `strict_types=1` on most of the PHP scripts, and adds types almost everywhere.

There are still a bit of work to do, but I'd say 80% of the job is done.

It also adds a `.vscode/launch.json` file to be able to debug the project when in VS Code, and it adds a `.vscode/settings.json` with a bunch of custom words to add to the cSpell dictionary.