### PR TITLE
fixup: unset driverNames reference before building vendor columns

### DIFF
--- a/src/Controller/ApiSubController.php
+++ b/src/Controller/ApiSubController.php
@@ -142,6 +142,7 @@ class ApiSubController
                 }
             }
         }
+        unset($driverNames);
 
         foreach ($vendors as $vendorName => $driverNames) {
             // Add separator before each vendor.


### PR DESCRIPTION
The current version of MesaMatrix has a bug in the column generation code that affects all generated tables on the site. I noticed this when trying to look for new KosmicKrisp features, which had been overwritten with a second lavapipe column.

The createColumns() loop left $driverNames as a reference to the last vendor, causing the second foreach to overwrite anything in the last column with the previous data.

This is a one line change that I've confirmed locally to fix the issue. Please let me know if you have any questions.

